### PR TITLE
Adding a header partial integration #453

### DIFF
--- a/src/book/mod.rs
+++ b/src/book/mod.rs
@@ -263,6 +263,10 @@ impl MDBook {
         let mut index = File::create(themedir.join("index.hbs"))?;
         index.write_all(theme::INDEX)?;
 
+        // header.hbs
+        let mut header = File::create(themedir.join("header.hbs"))?;
+        header.write_all(theme::HEADER)?;
+
         // book.css
         let mut css = File::create(themedir.join("book.css"))?;
         css.write_all(theme::CSS)?;

--- a/src/renderer/html_handlebars/hbs_renderer.rs
+++ b/src/renderer/html_handlebars/hbs_renderer.rs
@@ -253,8 +253,17 @@ impl Renderer for HtmlHandlebars {
 
         let theme = theme::Theme::new(theme_dir);
 
-        debug!("[*]: Register handlebars template");
-        handlebars.register_template_string("index", String::from_utf8(theme.index.clone())?)?;
+        debug!("[*]: Register the index handlebars template");
+        handlebars.register_template_string(
+            "index",
+            String::from_utf8(theme.index.clone())?,
+        )?;
+
+        debug!("[*]: Register the header handlebars template");
+        handlebars.register_partial(
+            "header",
+            String::from_utf8(theme.header.clone())?,
+        )?;
 
         debug!("[*]: Register handlebars helpers");
         self.register_hbs_helpers(&mut handlebars);

--- a/src/theme/header.hbs
+++ b/src/theme/header.hbs
@@ -1,0 +1,1 @@
+{{!-- Put your header HTML text here --}}

--- a/src/theme/index.hbs
+++ b/src/theme/index.hbs
@@ -74,6 +74,7 @@
         <div id="page-wrapper" class="page-wrapper">
 
             <div class="page" tabindex="-1">
+                {{> header}}
                 <div id="menu-bar" class="menu-bar">
                     <div class="left-buttons">
                         <i id="sidebar-toggle" class="fa fa-bars" title="Toggle sidebar"></i>

--- a/src/theme/mod.rs
+++ b/src/theme/mod.rs
@@ -7,6 +7,7 @@ use std::io::Read;
 use errors::*;
 
 pub static INDEX: &'static [u8] = include_bytes!("index.hbs");
+pub static HEADER: &'static [u8] = include_bytes!("header.hbs");
 pub static CSS: &'static [u8] = include_bytes!("book.css");
 pub static FAVICON: &'static [u8] = include_bytes!("favicon.png");
 pub static JS: &'static [u8] = include_bytes!("book.js");
@@ -40,6 +41,7 @@ pub static FONT_AWESOME_OTF: &'static [u8] = include_bytes!("_FontAwesome/fonts/
 #[derive(Debug, PartialEq)]
 pub struct Theme {
     pub index: Vec<u8>,
+    pub header: Vec<u8>,
     pub css: Vec<u8>,
     pub favicon: Vec<u8>,
     pub js: Vec<u8>,
@@ -64,17 +66,20 @@ impl Theme {
 
         // Check for individual files, if they exist copy them across
         {
-            let files = vec![(theme_dir.join("index.hbs"), &mut theme.index),
-                             (theme_dir.join("book.js"), &mut theme.js),
-                             (theme_dir.join("book.css"), &mut theme.css),
-                             (theme_dir.join("favicon.png"), &mut theme.favicon),
-                             (theme_dir.join("highlight.js"), &mut theme.highlight_js),
-                             (theme_dir.join("clipboard.min.js"), &mut theme.clipboard_js),
-                             (theme_dir.join("store.js"), &mut theme.store_js),
-                             (theme_dir.join("highlight.css"), &mut theme.highlight_css),
-                             (theme_dir.join("tomorrow-night.css"), &mut theme.tomorrow_night_css),
-                             (theme_dir.join("ayu-highlight.css"), &mut theme.ayu_highlight_css),
-                             (theme_dir.join("jquery.js"), &mut theme.jquery)];
+            let files = vec![
+                (theme_dir.join("index.hbs"), &mut theme.index),
+                (theme_dir.join("header.hbs"), &mut theme.header),
+                (theme_dir.join("book.js"), &mut theme.js),
+                (theme_dir.join("book.css"), &mut theme.css),
+                (theme_dir.join("favicon.png"), &mut theme.favicon),
+                (theme_dir.join("highlight.js"), &mut theme.highlight_js),
+                (theme_dir.join("clipboard.min.js"), &mut theme.clipboard_js),
+                (theme_dir.join("store.js"), &mut theme.store_js),
+                (theme_dir.join("highlight.css"), &mut theme.highlight_css),
+                (theme_dir.join("tomorrow-night.css"), &mut theme.tomorrow_night_css),
+                (theme_dir.join("ayu-highlight.css"), &mut theme.ayu_highlight_css),
+                (theme_dir.join("jquery.js"), &mut theme.jquery),
+            ];
 
             for (filename, dest) in files {
                 if !filename.exists() {
@@ -95,6 +100,7 @@ impl Default for Theme {
     fn default() -> Theme {
         Theme {
             index: INDEX.to_owned(),
+            header: HEADER.to_owned(),
             css: CSS.to_owned(),
             favicon: FAVICON.to_owned(),
             js: JS.to_owned(),
@@ -166,6 +172,7 @@ mod tests {
 
         let empty = Theme {
             index: Vec::new(),
+            header: Vec::new(),
             css: Vec::new(),
             favicon: Vec::new(),
             js: Vec::new(),


### PR DESCRIPTION
Addresses #453.

Giving this an initial stab.

I've tested it and it works: you need to point the theme at the location of your theme folder with the modified `header.hbs`, otherwise the default one is blank.

This still doesn't address the problem of additional classes/CSS, though...

Let me know what you think!