### PR TITLE
Use template to generate TOC

### DIFF
--- a/src/book/mod.rs
+++ b/src/book/mod.rs
@@ -264,7 +264,7 @@ impl MDBook {
         index.write_all(theme::INDEX)?;
 
         // toc.hbs
-        let mut toc = File::create(&themedir.join("toc.hbs"))?;
+        let mut toc = File::create(themedir.join("toc.hbs"))?;
         toc.write_all(theme::TOC)?;
 
         // book.css

--- a/src/book/mod.rs
+++ b/src/book/mod.rs
@@ -263,6 +263,10 @@ impl MDBook {
         let mut index = File::create(themedir.join("index.hbs"))?;
         index.write_all(theme::INDEX)?;
 
+        // toc.hbs
+        let mut toc = File::create(&themedir.join("toc.hbs"))?;
+        toc.write_all(theme::TOC)?;
+
         // book.css
         let mut css = File::create(themedir.join("book.css"))?;
         css.write_all(theme::CSS)?;

--- a/src/renderer/html_handlebars/hbs_renderer.rs
+++ b/src/renderer/html_handlebars/hbs_renderer.rs
@@ -436,7 +436,7 @@ fn make_data(book: &MDBook, config: &Config) -> Result<serde_json::Map<String, s
     }
 
     let chapters = make_chapters(book)?;
-    data.insert("toc".to_owned(), toc_json::from_chapters(chapters.as_slice())?);
+    data.insert("toc".to_owned(), toc_json::make_toc_tree(chapters.as_slice())?);
 
     debug!("[*]: JSON constructed");
     Ok(data)

--- a/src/renderer/html_handlebars/hbs_renderer.rs
+++ b/src/renderer/html_handlebars/hbs_renderer.rs
@@ -330,9 +330,7 @@ fn make_chapter(
 
     chapter.insert("name".to_owned(), item.name.to_owned());
 
-    let path = item.path.to_str().ok_or_else(|| {
-        io::Error::new(io::ErrorKind::Other, "Could not convert path to str")
-    })?;
+    let path = item.path.to_str().chain_err(|| "Could not convert path to str")?;
     chapter.insert("path".to_owned(), path.to_owned());
 
     previous.map(|previous| {

--- a/src/renderer/html_handlebars/helpers/navigation.rs
+++ b/src/renderer/html_handlebars/helpers/navigation.rs
@@ -3,9 +3,13 @@ use std::path::Path;
 use serde_json;
 use handlebars::{Context, Handlebars, Helper, RenderContext, RenderError, Renderable};
 
-fn find_chapter<'a>(chapter: &'a serde_json::Value, needle: &str) -> Result<Option<&'a serde_json::Map<String, serde_json::Value>>, RenderError> {
-    let chapter = chapter.as_object()
-        .ok_or_else(|| RenderError::new("Chapter is not an object"))?;
+fn find_chapter<'a>(
+    chapter: &'a serde_json::Value,
+    needle: &str)
+    -> Result<Option<&'a serde_json::Map<String, serde_json::Value>>, RenderError> {
+    let chapter =
+        chapter.as_object()
+               .ok_or_else(|| RenderError::new("Chapter is not an object"))?;
 
     if let Some(link) = chapter.get("link") {
         if link == needle {
@@ -14,8 +18,9 @@ fn find_chapter<'a>(chapter: &'a serde_json::Value, needle: &str) -> Result<Opti
     }
 
     if let Some(children) = chapter.get("children") {
-        let children = children.as_array()
-            .ok_or_else(|| RenderError::new("chapter.children is not an array"))?;
+        let children =
+            children.as_array()
+                    .ok_or_else(|| RenderError::new("chapter.children is not an array"))?;
 
         for child in children {
             if let Some(result) = find_chapter(child, needle)? {
@@ -27,14 +32,16 @@ fn find_chapter<'a>(chapter: &'a serde_json::Value, needle: &str) -> Result<Opti
     Ok(None)
 }
 
-fn current_chapter<'a>(rc: &'a RenderContext) -> Result<Option<&'a serde_json::Map<String, serde_json::Value>>, RenderError> {
+fn current_chapter<'a>(
+    rc: &'a RenderContext)
+    -> Result<Option<&'a serde_json::Map<String, serde_json::Value>>, RenderError> {
     let toc = rc.evaluate_absolute("toc")
-        .map_err(|_| RenderError::new("Could not find toc in context"))?;
+                .map_err(|_| RenderError::new("Could not find toc in context"))?;
 
     let current_path = rc.evaluate_absolute("path")?
-        .as_str()
-        .ok_or_else(|| RenderError::new("Type error for `path`, string expected"))?
-        .replace("\"", "");
+                         .as_str()
+                         .ok_or_else(|| RenderError::new("Type error for `path`, string expected"))?
+                         .replace("\"", "");
 
     let current_link = Path::new(&current_path)
         .with_extension("html")
@@ -46,15 +53,19 @@ fn current_chapter<'a>(rc: &'a RenderContext) -> Result<Option<&'a serde_json::M
     find_chapter(toc, &current_link)
 }
 
-fn nav_link(h: &Helper, r: &Handlebars, rc: &mut RenderContext, nav_obj_key: &str) -> Result<(), RenderError> {
-    if let Some(current) = current_chapter(rc)?.map(|v| v.clone()) {
+fn nav_link(h: &Helper,
+            r: &Handlebars,
+            rc: &mut RenderContext,
+            nav_obj_key: &str)
+            -> Result<(), RenderError> {
+    if let Some(current) = current_chapter(rc)?.cloned() {
         if let Some(nav_obj) = current.get(nav_obj_key) {
             h.template()
-                .ok_or_else(|| RenderError::new("Error with the handlebars template"))
-                .and_then(|t| {
-                    let mut local_rc = rc.with_context(Context::wraps(&nav_obj)?);
-                    t.render(r, &mut local_rc)
-                })?;
+             .ok_or_else(|| RenderError::new("Error with the handlebars template"))
+             .and_then(|t| {
+                           let mut local_rc = rc.with_context(Context::wraps(&nav_obj)?);
+                           t.render(r, &mut local_rc)
+                       })?;
         }
     }
 

--- a/src/renderer/html_handlebars/helpers/toc.rs
+++ b/src/renderer/html_handlebars/helpers/toc.rs
@@ -4,15 +4,17 @@ use handlebars::*;
 
 /// Link to the current page.
 fn active_link(rc: &RenderContext) -> Result<String, RenderError> {
-    Ok(Path::new(rc.evaluate_absolute("path")?
-              .as_str()
-              .ok_or_else(|| RenderError::new(
-                      "Type error for `path`, string expected"))?
-             )
+    let path = rc.evaluate_absolute("path")?
+        .as_str()
+        .ok_or_else(|| RenderError::new("Expected `path` to be string"))?;
+
+    let link = Path::new(path)
         .with_extension("html")
         .to_str()
         .unwrap()
-        .replace("\\", "/"))
+        .replace("\\", "/");
+
+    Ok(link)
 }
 
 /// Wrap a block in <a> if a link exists.

--- a/src/renderer/html_handlebars/helpers/toc.rs
+++ b/src/renderer/html_handlebars/helpers/toc.rs
@@ -21,26 +21,25 @@ fn active_link(rc: &RenderContext) -> Result<String, RenderError> {
 pub fn link(h: &Helper, r: &Handlebars, rc: &mut RenderContext) -> Result<(), RenderError> {
     let link = rc.evaluate("link")?.clone();
 
-    let has_link = if let Some(link) = link.as_str() {
+    if let Some(link) = link.as_str() {
         rc.writer.write_all(b"<a")?;
 
-        if active_link(rc)? == link {
+        let active = active_link(rc)?;
+
+        if active == link {
             rc.writer.write_all(b" class=\"active\"")?;
         }
 
         rc.writer.write_all(b" href=\"")?;
         rc.writer.write_all(link.as_bytes())?;
         rc.writer.write_all(b"\">")?;
-        true
-    } else {
-        false
-    };
+    }
 
     h.template()
         .ok_or_else(|| RenderError::new("No template for link"))
         .and_then(|t| t.render(r, rc))?;
 
-    if has_link {
+    if link.is_string() {
         rc.writer.write_all(b"</a>")?;
     }
 

--- a/src/renderer/html_handlebars/helpers/toc.rs
+++ b/src/renderer/html_handlebars/helpers/toc.rs
@@ -1,136 +1,46 @@
 use std::path::Path;
-use std::collections::BTreeMap;
 
-use serde_json;
-use handlebars::{Handlebars, Helper, HelperDef, RenderContext, RenderError};
-use pulldown_cmark::{html, Event, Parser, Tag};
+use handlebars::*;
 
-// Handlebars helper to construct TOC
-#[derive(Clone, Copy)]
-pub struct RenderToc;
+/// Link to the current page.
+fn active_link(rc: &RenderContext) -> Result<String, RenderError> {
+    Ok(Path::new(rc.evaluate_absolute("path")?
+              .as_str()
+              .ok_or_else(|| RenderError::new(
+                      "Type error for `path`, string expected"))?
+             )
+        .with_extension("html")
+        .to_str()
+        .unwrap()
+        .replace("\\", "/"))
+}
 
-impl HelperDef for RenderToc {
-    fn call(&self, _h: &Helper, _: &Handlebars, rc: &mut RenderContext) -> Result<(), RenderError> {
-        // get value from context data
-        // rc.get_path() is current json parent path, you should always use it like this
-        // param is the key of value you want to display
-        let chapters = rc.evaluate_absolute("chapters").and_then(|c| {
-            serde_json::value::from_value::<Vec<BTreeMap<String, String>>>(c.clone())
-                .map_err(|_| RenderError::new("Could not decode the JSON data"))
-        })?;
-        let current = rc.evaluate_absolute("path")?
-                        .as_str()
-                        .ok_or_else(|| RenderError::new("Type error for `path`, string expected"))?
-                        .replace("\"", "");
+/// Wrap a block in <a> if a link exists.
+pub fn link(h: &Helper, r: &Handlebars, rc: &mut RenderContext) -> Result<(), RenderError> {
+    let link = rc.evaluate("link")?.clone();
 
-        rc.writer.write_all(b"<ul class=\"chapter\">")?;
+    let has_link = if let Some(link) = link.as_str() {
+        rc.writer.write_all(b"<a")?;
 
-        let mut current_level = 1;
-
-        for item in chapters {
-            // Spacer
-            if item.get("spacer").is_some() {
-                rc.writer.write_all(b"<li class=\"spacer\"></li>")?;
-                continue;
-            }
-
-            let level = if let Some(s) = item.get("section") {
-                s.matches('.').count()
-            } else {
-                1
-            };
-
-            if level > current_level {
-                while level > current_level {
-                    rc.writer.write_all(b"<li>")?;
-                    rc.writer.write_all(b"<ul class=\"section\">")?;
-                    current_level += 1;
-                }
-                rc.writer.write_all(b"<li>")?;
-            } else if level < current_level {
-                while level < current_level {
-                    rc.writer.write_all(b"</ul>")?;
-                    rc.writer.write_all(b"</li>")?;
-                    current_level -= 1;
-                }
-                rc.writer.write_all(b"<li>")?;
-            } else {
-                rc.writer.write_all(b"<li")?;
-                if item.get("section").is_none() {
-                    rc.writer.write_all(b" class=\"affix\"")?;
-                }
-                rc.writer.write_all(b">")?;
-            }
-
-            // Link
-            let path_exists = if let Some(path) = item.get("path") {
-                if !path.is_empty() {
-                    rc.writer.write_all(b"<a href=\"")?;
-
-                    let tmp = Path::new(item.get("path").expect("Error: path should be Some(_)"))
-                        .with_extension("html")
-                        .to_str()
-                        .unwrap()
-                        // Hack for windows who tends to use `\` as separator instead of `/`
-                        .replace("\\", "/");
-
-                    // Add link
-                    rc.writer.write_all(tmp.as_bytes())?;
-                    rc.writer.write_all(b"\"")?;
-
-                    if path == &current {
-                        rc.writer.write_all(b" class=\"active\"")?;
-                    }
-
-                    rc.writer.write_all(b">")?;
-                    true
-                } else {
-                    false
-                }
-            } else {
-                false
-            };
-
-            // Section does not necessarily exist
-            if let Some(section) = item.get("section") {
-                rc.writer.write_all(b"<strong>")?;
-                rc.writer.write_all(section.as_bytes())?;
-                rc.writer.write_all(b"</strong> ")?;
-            }
-
-            if let Some(name) = item.get("name") {
-                // Render only inline code blocks
-
-                // filter all events that are not inline code blocks
-                let parser = Parser::new(name).filter(|event| match *event {
-                                                          Event::Start(Tag::Code) |
-                                                          Event::End(Tag::Code) |
-                                                          Event::InlineHtml(_) |
-                                                          Event::Text(_) => true,
-                                                          _ => false,
-                                                      });
-
-                // render markdown to html
-                let mut markdown_parsed_name = String::with_capacity(name.len() * 3 / 2);
-                html::push_html(&mut markdown_parsed_name, parser);
-
-                // write to the handlebars template
-                rc.writer.write_all(markdown_parsed_name.as_bytes())?;
-            }
-
-            if path_exists {
-                rc.writer.write_all(b"</a>")?;
-            }
-
-            rc.writer.write_all(b"</li>")?;
-        }
-        while current_level > 1 {
-            rc.writer.write_all(b"</ul>")?;
-            rc.writer.write_all(b"</li>")?;
-            current_level -= 1;
+        if active_link(rc)? == link {
+            rc.writer.write_all(b" class=\"active\"")?;
         }
 
-        rc.writer.write_all(b"</ul>")?;
-        Ok(())
+        rc.writer.write_all(b" href=\"")?;
+        rc.writer.write_all(link.as_bytes())?;
+        rc.writer.write_all(b"\">")?;
+        true
+    } else {
+        false
+    };
+
+    h.template()
+        .ok_or_else(|| RenderError::new("No template for link"))
+        .and_then(|t| t.render(r, rc))?;
+
+    if has_link {
+        rc.writer.write_all(b"</a>")?;
     }
+
+    Ok(())
 }

--- a/src/renderer/html_handlebars/mod.rs
+++ b/src/renderer/html_handlebars/mod.rs
@@ -2,3 +2,4 @@ pub use self::hbs_renderer::HtmlHandlebars;
 
 mod hbs_renderer;
 mod helpers;
+mod toc_json;

--- a/src/renderer/html_handlebars/toc_json.rs
+++ b/src/renderer/html_handlebars/toc_json.rs
@@ -120,3 +120,69 @@ pub fn make_toc_tree(chapters: &[BTreeMap<String, String>]) -> Result<serde_json
 
     Ok(path.pop().unwrap())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_make_toc_tree() {
+        let expected_toc = json!({
+            "children": [
+            {
+                "name": "Introduction",
+                "section": "1.",
+                "link": "intro.html",
+                "next": {
+                    "link": "start.html"
+                },
+                "children": [
+                {
+                    "name": "Getting started",
+                    "section": "1.1.",
+                    "link": "start.html",
+                    "previous": {
+                        "link": "intro.html"
+                    },
+                    "next": {
+                        "link": "indepth.html"
+                    }
+                }
+                ]
+            },
+            {
+                "name": "In depth",
+                "section": "2.",
+                "link": "indepth.html",
+                "previous": {
+                    "link": "start.html"
+                }
+            }
+            ]
+        });
+
+        let mut chapter1 = BTreeMap::new();
+        chapter1.insert("name".to_owned(), "Introduction".to_owned());
+        chapter1.insert("section".to_owned(), "1.".to_owned());
+        chapter1.insert("path".to_owned(), "intro".to_owned());
+        chapter1.insert("next_path".to_owned(), "start".to_owned());
+
+        let mut chapter2 = BTreeMap::new();
+        chapter2.insert("name".to_owned(), "Getting started".to_owned());
+        chapter2.insert("section".to_owned(), "1.1.".to_owned());
+        chapter2.insert("path".to_owned(), "start".to_owned());
+        chapter2.insert("next_path".to_owned(), "indepth".to_owned());
+        chapter2.insert("previous_path".to_owned(), "intro".to_owned());
+
+        let mut chapter3 = BTreeMap::new();
+        chapter3.insert("name".to_owned(), "In depth".to_owned());
+        chapter3.insert("section".to_owned(), "2.".to_owned());
+        chapter3.insert("path".to_owned(), "indepth".to_owned());
+        chapter3.insert("previous_path".to_owned(), "start".to_owned());
+
+        let chapters = vec![chapter1, chapter2, chapter3];
+        let toc = make_toc_tree(chapters.as_slice()).unwrap();
+
+        assert_eq!(toc, expected_toc);
+    }
+}

--- a/src/renderer/html_handlebars/toc_json.rs
+++ b/src/renderer/html_handlebars/toc_json.rs
@@ -1,0 +1,101 @@
+use std::collections::BTreeMap;
+use std::path::Path;
+
+use pulldown_cmark::{html, Parser, Event, Tag};
+use serde_json;
+use errors::*;
+
+/// Set name etc for a chapter.
+fn set_props(map: &mut BTreeMap<String, serde_json::Value>, item: &BTreeMap<String, String>) {
+    if let Some(path) = item.get("path") {
+        if !path.is_empty() {
+            let tmp = Path::new(item.get("path").expect("Error: path should be Some(_)"))
+                .with_extension("html")
+                .to_str()
+                .unwrap()
+                // Hack for windows who tends to use `\` as separator instead of `/`
+                .replace("\\", "/");
+
+            map.insert("link".to_owned(), json!(tmp));
+        }
+    }
+
+    // Section does not necessarily exist
+    if let Some(section) = item.get("section") {
+        map.insert("section".to_owned(), json!(section));
+    }
+
+    if let Some(name) = item.get("name") {
+        // filter all events that are not inline code blocks
+        let parser = Parser::new(name).filter(|event| match *event {
+            Event::Start(Tag::Code) |
+                Event::End(Tag::Code) |
+                Event::InlineHtml(_) |
+                Event::Text(_) => true,
+            _ => false,
+        });
+
+        // render markdown to html
+        let mut markdown_parsed_name = String::with_capacity(name.len() * 3 / 2);
+        html::push_html(&mut markdown_parsed_name, parser);
+
+        map.insert("name".to_owned(), json!(markdown_parsed_name));
+    }
+}
+
+/// Extend or collapse levels to reach a certain depth.
+fn set_level(level: usize, levels: &mut Vec<serde_json::Value>) {
+    // Can't pop root node
+    assert!(level > 0);
+
+    while level > levels.len() {
+        levels.push(json!({}));
+    }
+
+    while level < levels.len() {
+        // Push child into parent.children
+        let child = levels.pop().unwrap();
+        let mut parent = levels.last_mut()
+            .unwrap()
+            .as_object_mut()
+            .unwrap();
+
+        if !parent.contains_key("children") {
+            parent.insert("children".to_owned(), json!([]));
+        }
+
+        parent.get_mut("children")
+            .unwrap()
+            .as_array_mut()
+            .unwrap()
+            .push(child);
+    }
+}
+
+pub fn from_chapters(chapters: &[BTreeMap<String, String>]) -> Result<serde_json::Value> {
+    let mut levels = vec![];
+
+    for item in chapters {
+        let mut current = BTreeMap::new();
+
+        if item.get("spacer").is_some() {
+            set_level(1, &mut levels);
+            current.insert("spacer".to_owned(), json!(true));
+        } else {
+            let level = if let Some(s) = item.get("section") {
+                ::std::cmp::max(s.matches('.').count(), 1)
+            } else {
+                1
+            };
+
+            set_level(level, &mut levels);
+            set_props(&mut current, item);
+        }
+
+        levels.push(json!(current));
+    }
+
+    set_level(1, &mut levels);
+
+    return Ok(levels.pop().unwrap());
+}

--- a/src/renderer/html_handlebars/toc_json.rs
+++ b/src/renderer/html_handlebars/toc_json.rs
@@ -30,12 +30,12 @@ fn set_props(map: &mut BTreeMap<String, serde_json::Value>, item: &BTreeMap<Stri
     if let Some(name) = item.get("name") {
         // filter all events that are not inline code blocks
         let parser = Parser::new(name).filter(|event| match *event {
-            Event::Start(Tag::Code) |
-                Event::End(Tag::Code) |
-                Event::InlineHtml(_) |
-                Event::Text(_) => true,
-            _ => false,
-        });
+                                                  Event::Start(Tag::Code) |
+                                                  Event::End(Tag::Code) |
+                                                  Event::InlineHtml(_) |
+                                                  Event::Text(_) => true,
+                                                  _ => false,
+                                              });
 
         // render markdown to html
         let mut markdown_parsed_name = String::with_capacity(name.len() * 3 / 2);
@@ -45,11 +45,17 @@ fn set_props(map: &mut BTreeMap<String, serde_json::Value>, item: &BTreeMap<Stri
     }
 
     if let Some(previous_path) = item.get("previous_path") {
-        map.insert("previous".to_owned(), json!({"link": path_to_link(previous_path)}));
+        map.insert("previous".to_owned(),
+                   json!({
+                             "link": path_to_link(previous_path)
+                         }));
     }
 
     if let Some(next_path) = item.get("next_path") {
-        map.insert("next".to_owned(), json!({"link": path_to_link(next_path)}));
+        map.insert("next".to_owned(),
+                   json!({
+                             "link": path_to_link(next_path)
+                         }));
     }
 }
 
@@ -65,20 +71,17 @@ fn set_level(level: usize, levels: &mut Vec<serde_json::Value>) {
     while level < levels.len() {
         // Push child into parent.children
         let child = levels.pop().unwrap();
-        let mut parent = levels.last_mut()
-            .unwrap()
-            .as_object_mut()
-            .unwrap();
+        let parent = levels.last_mut().unwrap().as_object_mut().unwrap();
 
         if !parent.contains_key("children") {
             parent.insert("children".to_owned(), json!([]));
         }
 
         parent.get_mut("children")
-            .unwrap()
-            .as_array_mut()
-            .unwrap()
-            .push(child);
+              .unwrap()
+              .as_array_mut()
+              .unwrap()
+              .push(child);
     }
 }
 
@@ -107,5 +110,5 @@ pub fn from_chapters(chapters: &[BTreeMap<String, String>]) -> Result<serde_json
 
     set_level(1, &mut levels);
 
-    return Ok(levels.pop().unwrap());
+    Ok(levels.pop().unwrap())
 }

--- a/src/theme/index.hbs
+++ b/src/theme/index.hbs
@@ -68,7 +68,11 @@
         </script>
 
         <div id="sidebar" class="sidebar">
-            {{#toc}}{{/toc}}
+            {{#with toc}}
+            <ul class="chapter">
+                {{> toc}}
+            </ul>
+            {{/with}}
         </div>
 
         <div id="page-wrapper" class="page-wrapper">

--- a/src/theme/mod.rs
+++ b/src/theme/mod.rs
@@ -7,6 +7,7 @@ use std::io::Read;
 use errors::*;
 
 pub static INDEX: &'static [u8] = include_bytes!("index.hbs");
+pub static TOC: &'static [u8] = include_bytes!("toc.hbs");
 pub static CSS: &'static [u8] = include_bytes!("book.css");
 pub static FAVICON: &'static [u8] = include_bytes!("favicon.png");
 pub static JS: &'static [u8] = include_bytes!("book.js");
@@ -40,6 +41,7 @@ pub static FONT_AWESOME_OTF: &'static [u8] = include_bytes!("_FontAwesome/fonts/
 #[derive(Debug, PartialEq)]
 pub struct Theme {
     pub index: Vec<u8>,
+    pub toc: Vec<u8>,
     pub css: Vec<u8>,
     pub favicon: Vec<u8>,
     pub js: Vec<u8>,
@@ -65,6 +67,7 @@ impl Theme {
         // Check for individual files, if they exist copy them across
         {
             let files = vec![(theme_dir.join("index.hbs"), &mut theme.index),
+                             (theme_dir.join("toc.hbs"), &mut theme.toc),
                              (theme_dir.join("book.js"), &mut theme.js),
                              (theme_dir.join("book.css"), &mut theme.css),
                              (theme_dir.join("favicon.png"), &mut theme.favicon),
@@ -95,6 +98,7 @@ impl Default for Theme {
     fn default() -> Theme {
         Theme {
             index: INDEX.to_owned(),
+            toc: TOC.to_owned(),
             css: CSS.to_owned(),
             favicon: FAVICON.to_owned(),
             js: JS.to_owned(),
@@ -166,6 +170,7 @@ mod tests {
 
         let empty = Theme {
             index: Vec::new(),
+            toc: Vec::new(),
             css: Vec::new(),
             favicon: Vec::new(),
             js: Vec::new(),

--- a/src/theme/toc.hbs
+++ b/src/theme/toc.hbs
@@ -1,0 +1,23 @@
+{{#each children}}
+    {{#if spacer}}
+        <li class=spacer></li>
+    {{else}}
+        {{#if section}}
+        <li>
+        {{else}}
+        <li class="affix">
+        {{/if}}
+        {{#link}}
+            {{#if section}}
+                <strong>{{ section }}</strong>
+            {{/if}}
+            {{ name }}
+        {{/link}}
+        </li>
+        {{#if children}}
+            <ul class="section">
+                {{> toc}}
+            </ul>
+        {{/if}}
+    {{/if}}
+{{/each}}


### PR DESCRIPTION
Instead of directly writing html from Rust, use a Handlebars template to generate the table of contents. This requires build a separate json object from `chapters`. To remove the duplicated data, the second commit adapts navigation to use the new `toc` json object instead, and is an alternative to #465.

Pros:
- toc is easy to edit and customisable
- code is more maintainable

Cons:
- the template generates funky html with lots of whitespace (will look for a solution)
- complicated template -- some handlebars knowledge required
- book chapters are processed in two steps (can probably join them to cut down code)

I'm not quite sure how to organise the code. Perhaps `toc_json.rs` could be merged with `helpers/toc.rs`. I'm also not sure when to trust the code and use `unwrap` and when passing along errors is preferred.

#458 