### PR TITLE
Improve experience on smaller screens

### DIFF
--- a/src/theme/book.css
+++ b/src/theme/book.css
@@ -1,7 +1,7 @@
-html,
-body {
+html {
   font-family: "Open Sans", sans-serif;
   color: #333;
+  overflow-x: hidden;
 }
 body {
   margin: 0;

--- a/src/theme/book.css
+++ b/src/theme/book.css
@@ -228,32 +228,41 @@ table thead td {
   -ms-transition: color 0.5s;
   transition: color 0.5s;
 }
-.mobile-nav-chapters {
-  display: none;
-}
 .nav-chapters:hover {
   text-decoration: none;
 }
+.nav-wrapper {
+  margin-top: 50px;
+  display: none;
+}
+.mobile-nav-chapters {
+  font-size: 2.5em;
+  text-align: center;
+  text-decoration: none;
+  width: 90px;
+  border-radius: 5px;
+}
 .previous {
-  left: 15px;
-  -webkit-transition: left 0.5s;
-  -moz-transition: left 0.5s;
-  -o-transition: left 0.5s;
-  -ms-transition: left 0.5s;
-  transition: left 0.5s;
+  float: left;
 }
 .next {
+  float: right;
   right: 15px;
 }
-@media only screen and (min-width: 1251px) {
-  .sidebar-visible .previous {
-    left: 315px;
+@media only screen and (max-width: 1080px) {
+  .nav-chapters {
+    display: none;
+  }
+  .nav-wrapper {
+    display: block;
   }
 }
-@media only screen and (max-width: 1060px) {
-  .nav-wrapper {
-    max-width: 750px;
-    margin: 0 auto;
+@media only screen and (max-width: 1380px) {
+  .sidebar-visible .nav-chapters {
+    display: none;
+  }
+  .sidebar-visible .nav-wrapper {
+    display: block;
   }
 }
 .theme-popup {
@@ -274,37 +283,6 @@ table thead td {
 .theme-popup .theme:hover:last-child {
   border-top-left-radius: inherit;
   border-top-right-radius: inherit;
-}
-@media only screen and (max-width: 1060px) {
-  .nav-chapters {
-    display: none;
-  }
-  .mobile-nav-chapters {
-    font-size: 2.5em;
-    text-align: center;
-    text-decoration: none;
-    max-width: 150px;
-    min-width: 90px;
-    -webkit-box-pack: center;
-    -moz-box-pack: center;
-    -o-box-pack: center;
-    -ms-flex-pack: center;
-    -webkit-justify-content: center;
-    justify-content: center;
-    -ms-flex-line-pack: center;
-    -webkit-align-content: center;
-    align-content: center;
-    position: relative;
-    display: inline-block;
-    margin-bottom: 50px;
-    border-radius: 5px;
-  }
-  .next {
-    float: right;
-  }
-  .previous {
-    float: left;
-  }
 }
 .light {
   color: #333;

--- a/src/theme/book.css
+++ b/src/theme/book.css
@@ -6,6 +6,7 @@ body {
 body {
   margin: 0;
   font-size: 1rem;
+  overflow-x: hidden;
 }
 code {
   font-family: "Source Code Pro", Consolas, "Ubuntu Mono", Menlo, "DejaVu Sans Mono", monospace, monospace;
@@ -109,28 +110,25 @@ table thead td {
   white-space: nowrap;
 }
 .page-wrapper {
-  padding-left: 300px;
   -webkit-box-sizing: border-box;
   -moz-box-sizing: border-box;
   box-sizing: border-box;
   min-height: 100%;
-  -webkit-transition: padding-left 0.5s, margin-right 0.5s;
-  -moz-transition: padding-left 0.5s, margin-right 0.5s;
-  -o-transition: padding-left 0.5s, margin-right 0.5s;
-  -ms-transition: padding-left 0.5s, margin-right 0.5s;
-  transition: padding-left 0.5s, margin-right 0.5s;
-}
-@media only screen and (max-width: 1060px) {
-  .page-wrapper {
-    padding-left: 0;
-  }
-}
-.sidebar-hidden .page-wrapper {
-  padding-left: 0;
+  width: 100%;
+  -webkit-transition: padding-left 0.5s, margin-left 0.5s;
+  -moz-transition: padding-left 0.5s, margin-left 0.5s;
+  -o-transition: padding-left 0.5s, margin-left 0.5s;
+  -ms-transition: padding-left 0.5s, margin-left 0.5s;
+  transition: padding-left 0.5s, margin-left 0.5s;
 }
 .sidebar-visible .page-wrapper {
   padding-left: 300px;
-  margin-right: -300px;
+}
+@media only screen and (max-width: 1079px) {
+  .sidebar-visible .page-wrapper {
+    padding-left: 0;
+    margin-left: 300px;
+  }
 }
 .page {
   outline: 0;

--- a/src/theme/book.css
+++ b/src/theme/book.css
@@ -67,19 +67,11 @@ table thead td {
   -ms-transition: left 0.5s;
   transition: left 0.5s;
 }
-@media only screen and (max-width: 1060px) {
-  .sidebar {
-    left: -300px;
-  }
-}
 .sidebar code {
   line-height: 2em;
 }
 .sidebar-hidden .sidebar {
   left: -300px;
-}
-.sidebar-visible .sidebar {
-  left: 0;
 }
 .chapter {
   list-style: none outside none;
@@ -243,26 +235,20 @@ table thead td {
   text-decoration: none;
 }
 .previous {
-  left: 315px;
+  left: 15px;
   -webkit-transition: left 0.5s;
   -moz-transition: left 0.5s;
   -o-transition: left 0.5s;
   -ms-transition: left 0.5s;
   transition: left 0.5s;
 }
-@media only screen and (max-width: 1060px) {
-  .previous {
-    left: 15px;
-  }
-}
 .next {
   right: 15px;
 }
-.sidebar-hidden .previous {
-  left: 15px;
-}
-.sidebar-visible .previous {
-  left: 315px;
+@media only screen and (min-width: 1251px) {
+  .sidebar-visible .previous {
+    left: 315px;
+  }
 }
 @media only screen and (max-width: 1060px) {
   .nav-wrapper {

--- a/src/theme/book.js
+++ b/src/theme/book.js
@@ -68,14 +68,6 @@ $( document ).ready(function() {
     // Toggle sidebar
     $("#sidebar-toggle").click(sidebarToggle);
 
-    // Hide sidebar on section link click if it occupies large space
-    // in relation to the whole screen (phone in portrait)
-    $("#sidebar a").click(function(event){
-        if (sidebar.width() > window.screen.width * 0.4) {
-            sidebarToggle();
-        }
-    });
-
     // Scroll sidebar to current active section
     var activeSection = sidebar.find(".active");
     if(activeSection.length) {

--- a/src/theme/index.hbs
+++ b/src/theme/index.hbs
@@ -93,30 +93,24 @@
 
                 <div id="content" class="content">
                     {{{ content }}}
+
+                    <div class="nav-wrapper">
+                        <!-- Mobile navigation buttons -->
+                        {{#previous}}
+                            <a rel="prev" href="{{link}}" class="mobile-nav-chapters previous" title="Previous chapter">
+                                <i class="fa fa-angle-left"></i>
+                            </a>
+                        {{/previous}}
+
+                        {{#next}}
+                            <a rel="next" href="{{link}}" class="mobile-nav-chapters next" title="Next chapter">
+                                <i class="fa fa-angle-right"></i>
+                            </a>
+                        {{/next}}
+
+                        <div style="clear: both"></div>
+                    </div>
                 </div>
-
-                <!--
-                Constrain the space between buttons on small screen so the total
-                width of the buttons group will not exceed the main content
-                above.
-                -->
-                <div class="nav-wrapper">
-                    <!-- Mobile navigation buttons -->
-                    {{#previous}}
-                        <a rel="prev" href="{{link}}" class="mobile-nav-chapters previous" title="Previous chapter">
-                            <i class="fa fa-angle-left"></i>
-                        </a>
-                    {{/previous}}
-
-                    {{#next}}
-                        <a rel="next" href="{{link}}" class="mobile-nav-chapters next" title="Next chapter">
-                            <i class="fa fa-angle-right"></i>
-                        </a>
-                    {{/next}}
-
-                    <div style="clear: both"></div>
-                </div>
-
             </div>
 
             {{#previous}}

--- a/src/theme/index.hbs
+++ b/src/theme/index.hbs
@@ -62,9 +62,10 @@
 
         <!-- Hide / unhide sidebar before it is displayed -->
         <script type="text/javascript">
-            var sidebar = store.get('mdbook-sidebar');
-            if (sidebar === "hidden") { $("html").addClass("sidebar-hidden") }
-            else if (sidebar === "visible") { $("html").addClass("sidebar-visible") }
+            var sidebar = 'hidden';
+            if (document.body.clientWidth >= 1080)
+                sidebar = store.get('mdbook-sidebar') || 'visible';
+            $("html").addClass("sidebar-" + sidebar);
         </script>
 
         <div id="sidebar" class="sidebar">

--- a/src/theme/stylus/general.styl
+++ b/src/theme/stylus/general.styl
@@ -6,6 +6,7 @@ html, body {
 body {
     margin: 0;
     font-size: 1rem;
+    overflow-x: hidden
 }
 
 code {

--- a/src/theme/stylus/general.styl
+++ b/src/theme/stylus/general.styl
@@ -1,6 +1,7 @@
-html, body {
+html {
     font-family: "Open Sans", sans-serif
     color: #333
+    overflow-x: hidden
 }
 
 body {

--- a/src/theme/stylus/nav-icons.styl
+++ b/src/theme/stylus/nav-icons.styl
@@ -20,21 +20,15 @@
 .mobile-nav-chapters { display: none }
 .nav-chapters:hover { text-decoration: none }
 .previous {
-    left: $sidebar-width + $page-padding
+    left: $page-padding
     transition: left 0.5s
-
-    @media only screen and (max-width: $max-page-width-with-hidden-sidebar) {
-        left: $page-padding
-    }
 }
 .next { right: $page-padding }
 
-.sidebar-hidden .previous {
-  left: $page-padding
-}
-
-.sidebar-visible .previous {
-  left: $sidebar-width + $page-padding
+@media only screen and (min-width: 1251px) {
+    .sidebar-visible .previous {
+        left: $sidebar-width + $page-padding
+    }
 }
 
 .nav-wrapper {

--- a/src/theme/stylus/nav-icons.styl
+++ b/src/theme/stylus/nav-icons.styl
@@ -9,6 +9,7 @@
     margin: 0
     max-width: 150px
     min-width: 90px
+
     display: flex
     justify-content: center
     align-content: center
@@ -17,23 +18,38 @@
     transition: color 0.5s
 }
 
-.mobile-nav-chapters { display: none }
 .nav-chapters:hover { text-decoration: none }
-.previous {
-    left: $page-padding
-    transition: left 0.5s
-}
-.next { right: $page-padding }
-
-@media only screen and (min-width: 1251px) {
-    .sidebar-visible .previous {
-        left: $sidebar-width + $page-padding
-    }
-}
 
 .nav-wrapper {
-  @media only screen and (max-width: $max-page-width-with-hidden-sidebar) {
-    max-width: $content-max-width
-    margin: 0 auto
-  }
+    margin-top: 50px
+    display: none
+}
+
+.mobile-nav-chapters { 
+    font-size: 2.5em
+    text-align: center
+    text-decoration: none
+    width: 90px
+    border-radius: 5px
+}
+
+.previous {
+    float: left
+}
+
+.next {
+    float: right
+    right: $page-padding 
+}
+
+@media only screen and (max-width: $page-plus-sidebar-width) {
+    .nav-chapters { display: none }
+    .nav-wrapper { display: block }
+}
+
+@media only screen and (max-width: $page-plus-sidebar-width + $sidebar-width) {
+    .sidebar-visible {
+        .nav-chapters { display: none }
+        .nav-wrapper { display: block }
+    }
 }

--- a/src/theme/stylus/page.styl
+++ b/src/theme/stylus/page.styl
@@ -1,26 +1,24 @@
 @require 'variables'
 
 .page-wrapper {
-    padding-left: $sidebar-width
     box-sizing: border-box
 
     min-height: 100%
+    width: 100%
 
     // Animation: slide away
-    transition: padding-left 0.5s, margin-right 0.5s
-
-    @media only screen and (max-width: $max-page-width-with-hidden-sidebar) {
-        padding-left: 0
-    }
-}
-
-.sidebar-hidden .page-wrapper {
-    padding-left: 0
+    transition: padding-left 0.5s, margin-left 0.5s
 }
 
 .sidebar-visible .page-wrapper {
     padding-left: $sidebar-width
-    margin-right: - $sidebar-width
+}
+
+@media only screen and (max-width: $page-plus-sidebar-width - 1) {
+    .sidebar-visible .page-wrapper {
+        padding-left: 0
+        margin-left: $sidebar-width
+    }
 }
 
 .page {
@@ -30,7 +28,7 @@
 
 .content {
     margin-left: auto
-    margin-right:auto
+    margin-right: auto
     max-width: $content-max-width
     padding-bottom: 50px
 

--- a/src/theme/stylus/sidebar.styl
+++ b/src/theme/stylus/sidebar.styl
@@ -15,10 +15,6 @@
     // Animation: slide away
     transition: left 0.5s
 
-    @media only screen and (max-width: $max-page-width-with-hidden-sidebar) {
-        left: - $sidebar-width
-    }
-
     code {
         line-height: 2em;
     }
@@ -26,10 +22,6 @@
 
 .sidebar-hidden .sidebar {
     left: - $sidebar-width
-}
-
-.sidebar-visible .sidebar {
-    left: 0
 }
 
 .chapter {

--- a/src/theme/stylus/theme-popup.styl
+++ b/src/theme/stylus/theme-popup.styl
@@ -22,36 +22,3 @@
     }
 
 }
-
-@media only screen and (max-width: $max-page-width-with-hidden-sidebar) {
-
-    .nav-chapters {
-        display: none
-    }
-
-    .mobile-nav-chapters {
-        font-size: 2.5em
-        text-align: center
-        text-decoration: none
-
-        max-width: 150px
-        min-width: 90px
-
-        justify-content: center
-        align-content: center
-
-        position: relative
-        display: inline-block
-        margin-bottom: 50px
-
-        border-radius: 5px
-    }
-
-    .next {
-        float: right
-    }
-
-    .previous {
-        float: left
-    }
-}

--- a/src/theme/stylus/variables.styl
+++ b/src/theme/stylus/variables.styl
@@ -1,4 +1,5 @@
 $sidebar-width = 300px
 $page-padding = 15px
-$max-page-width-with-hidden-sidebar = 1060px
 $content-max-width = 750px
+$max-page-width-with-hidden-sidebar = 1060px
+$page-plus-sidebar-width = $content-max-width + $sidebar-width + $page-padding * 2

--- a/src/theme/stylus/variables.styl
+++ b/src/theme/stylus/variables.styl
@@ -1,5 +1,4 @@
 $sidebar-width = 300px
 $page-padding = 15px
 $content-max-width = 750px
-$max-page-width-with-hidden-sidebar = 1060px
 $page-plus-sidebar-width = $content-max-width + $sidebar-width + $page-padding * 2


### PR DESCRIPTION
At lower screen widths, when the sidebar is visible or transitioning to/from visible, the page wrapper will attempt to fit within the remaining screen width. On mobile devices, this leads to undesirable line wrapping and overflow. This change sets the width of the page wrapper to be equivalent to the screen width when the screen width is less than the sidebar width plus the maximum content width (1080px), simply causing the sidebar to push the page wrapper off-screen when it is visible.

Before and after:
![mdbook-sidebar](https://user-images.githubusercontent.com/181157/31570256-ed230b0a-b04f-11e7-81d5-3f36833423f8.png)

I also changed some behavior regarding the sidebar's state when the page is loaded. If the screen width is less than 1080px, it will be hidden (so it doesn't load with the content pushed off-screen). Otherwise, it uses the stored value, defaulting to visible if there isn't one.