### PR TITLE
WIP: Add option to disable section numbers in the table of contents

### DIFF
--- a/book-example/src/format/config.md
+++ b/book-example/src/format/config.md
@@ -35,6 +35,8 @@ This is general information about your book.
 - **src:** By default, the source directory is found in the directory named
   `src` directly under the root folder. But this is configurable with the `src`
   key in the configuration file.
+- **section-numbers:** By default, sections are numbered in the table of
+  contents. Setting this to `false` disables numbering.
 
 **book.toml**
 ```toml
@@ -43,6 +45,7 @@ title = "Example book"
 authors = ["John Doe", "Jane Doe"]
 description = "The example book covers examples."
 src = "my-src"  # the source files will be found in `root/my-src` instead of `root/src`
+section-numbers = false
 ```
 
 ### Build options

--- a/src/book/bookitem.rs
+++ b/src/book/bookitem.rs
@@ -2,10 +2,11 @@ use serde::{Serialize, Serializer};
 use serde::ser::SerializeStruct;
 use std::path::PathBuf;
 
+type Section = Vec<i32>;
 
 #[derive(Debug, Clone)]
 pub enum BookItem {
-    Chapter(String, Chapter), // String = section
+    Chapter(Section, Chapter),
     Affix(Chapter),
     Spacer,
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -209,6 +209,8 @@ pub struct BookConfig {
     pub src: PathBuf,
     /// Does this book support more than one language?
     pub multilingual: bool,
+    /// Should sections be numbered in the TOC?
+    pub section_numbers: bool,
 }
 
 impl Default for BookConfig {
@@ -219,6 +221,7 @@ impl Default for BookConfig {
             description: None,
             src: PathBuf::from("src"),
             multilingual: false,
+            section_numbers: true,
         }
     }
 }
@@ -274,6 +277,7 @@ mod tests {
         description = "A completely useless book"
         multilingual = true
         src = "source"
+        section-numbers = false
 
         [build]
         build-dir = "outputs"
@@ -300,6 +304,7 @@ mod tests {
             description: Some(String::from("A completely useless book")),
             multilingual: true,
             src: PathBuf::from("source"),
+            section_numbers: false,
             ..Default::default()
         };
         let build_should_be = BuildConfig {

--- a/src/parse/summary.rs
+++ b/src/parse/summary.rs
@@ -110,9 +110,7 @@ fn parse_level(summary: &mut Vec<&str>,
                         // Increment section
                         let len = section.len() - 1;
                         section[len] += 1;
-                        let s = section.iter()
-                                       .fold("".to_owned(), |s, i| s + &i.to_string() + ".");
-                        BookItem::Chapter(s, ch)
+                        BookItem::Chapter(section.clone(), ch)
                     }
                     _ => parsed_item,
                 }
@@ -181,7 +179,7 @@ fn parse_line(l: &str) -> Option<BookItem> {
                 debug!("[*]: Line is list element");
 
                 if let Some((name, path)) = read_link(line) {
-                    return Some(BookItem::Chapter("0".to_owned(), Chapter::new(name, path)));
+                    return Some(BookItem::Chapter(vec![0], Chapter::new(name, path)));
                 } else {
                     return None;
                 }

--- a/src/renderer/html_handlebars/hbs_renderer.rs
+++ b/src/renderer/html_handlebars/hbs_renderer.rs
@@ -407,7 +407,9 @@ fn make_data(book: &MDBook, config: &Config) -> Result<serde_json::Map<String, s
                 chapter.insert("path".to_owned(), json!(path));
             }
             BookItem::Chapter(ref s, ref ch) => {
-                chapter.insert("section".to_owned(), json!(s));
+                let section = s.iter()
+                               .fold("".to_owned(), |s, i| s + &i.to_string() + ".");
+                chapter.insert("section".to_owned(), json!(section));
                 chapter.insert("name".to_owned(), json!(ch.name));
                 let path = ch.path.to_str().ok_or_else(|| {
                                                            io::Error::new(io::ErrorKind::Other,

--- a/src/renderer/html_handlebars/hbs_renderer.rs
+++ b/src/renderer/html_handlebars/hbs_renderer.rs
@@ -407,9 +407,15 @@ fn make_data(book: &MDBook, config: &Config) -> Result<serde_json::Map<String, s
                 chapter.insert("path".to_owned(), json!(path));
             }
             BookItem::Chapter(ref s, ref ch) => {
-                let section = s.iter()
-                               .fold("".to_owned(), |s, i| s + &i.to_string() + ".");
-                chapter.insert("section".to_owned(), json!(section));
+                let level = format!("{}", s.len());
+                chapter.insert("level".to_owned(), json!(level));
+
+                if config.book.section_numbers {
+                    let section = s.iter()
+                                   .fold("".to_owned(), |s, i| s + &i.to_string() + ".");
+                    chapter.insert("section".to_owned(), json!(section));
+                }
+
                 chapter.insert("name".to_owned(), json!(ch.name));
                 let path = ch.path.to_str().ok_or_else(|| {
                                                            io::Error::new(io::ErrorKind::Other,

--- a/src/renderer/html_handlebars/helpers/toc.rs
+++ b/src/renderer/html_handlebars/helpers/toc.rs
@@ -34,8 +34,8 @@ impl HelperDef for RenderToc {
                 continue;
             }
 
-            let level = if let Some(s) = item.get("section") {
-                s.matches('.').count()
+            let level = if let Some(s) = item.get("level") {
+                s.parse().expect(&format!("Error: level expected integer, got \"{}\"", s))
             } else {
                 1
             };


### PR DESCRIPTION
This is as much a request for comments as anything else.  I've added the ability to not display section numbers in the table of contents.  Nesting is still allowed: the only difference is that the section numbers themselves are not displayed.

The one large issue with this is that, as it stands, mdBook is somewhat centered on the idea of numbered sections.  By removing the section numbers, prefix and suffix chapters become redundant.  And the documentation refers to the "main" section of the book as numbered chapters.

Obviously there's no harm in keeping prefix and suffix chapters, as this patch does: you can either use or ignore them.  It may be somewhat confusing to keep them around, documentation-wise, but if they're removed when numbered sections are turned off, then the book building (code wise) becomes a lot more complex; plus you can't test what a book with prefix/suffix chapters would look like without section numbers without some surgery to `SUMMARY.md`.

Anyway, as I said, this is mainly to get some comments about this idea, whether it's at all desirable.