### PR TITLE
Added a quick fix so if the config isn't found we use a default

### DIFF
--- a/src/book/mod.rs
+++ b/src/book/mod.rs
@@ -299,8 +299,13 @@ impl MDBook {
 
     pub fn read_config(mut self) -> Result<Self> {
         let config_path = self.root.join("book.toml");
-        debug!("[*] Loading the config from {}", config_path.display());
-        self.config = Config::from_disk(&config_path)?;
+
+        if config_path.exists() {
+            debug!("[*] Loading the config from {}", config_path.display());
+            self.config = Config::from_disk(&config_path)?;
+        } else {
+            self.config = Config::default();
+        }
 
         Ok(self)
     }

--- a/tests/init.rs
+++ b/tests/init.rs
@@ -51,3 +51,14 @@ fn run_mdbook_init_with_custom_book_and_src_locations() {
         assert!(target.exists(), "{} should have been created by `mdbook init`", file);
     }
 }
+
+#[test]
+fn book_toml_isnt_required() {
+    let temp = TempDir::new("mdbook").unwrap();
+    let mut md = MDBook::new(temp.path());
+    md.init().unwrap();
+
+    assert!(!temp.path().join("book.toml").exists());
+
+    md.read_config().unwrap().build().unwrap();
+}


### PR DESCRIPTION
> So, this is now causing the nomicon to fail building: https://travis-ci.org/rust-lang-nursery/nomicon/builds/313641706?utm_source=email&utm_medium=notification
>
> is book.toml required now?

It looks like I accidentally made `book.toml` required in #457 instead of falling back to the default `Config` if it doesn't exist. This fixes that issue.

([comment])

[comment]: https://github.com/rust-lang-nursery/mdBook/pull/457#issuecomment-350354816