### PR TITLE
Implement playpen defaults

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -274,10 +274,20 @@ pub struct HtmlConfig {
 }
 
 /// Configuration for tweaking how the the HTML renderer handles the playpen.
-#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(default, rename_all = "kebab-case")]
 pub struct Playpen {
     pub editor: PathBuf,
     pub editable: bool,
+}
+
+impl Default for Playpen {
+    fn default() -> Playpen {
+        Playpen {
+            editor: PathBuf::from("ace"),
+            editable: false,
+        }
+    }
 }
 
 


### PR DESCRIPTION
Avoids issues where we enable `editable` but forget to specify `editor` (eg, https://github.com/rust-lang/rust-by-example/issues/963). 
Since we already include Ace editor, seems like we can just treat it as the default.