### PR TITLE
Update travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,6 @@ matrix:
   - env: TARGET=aarch64-unknown-linux-gnu
   - env: TARGET=arm-unknown-linux-gnueabi
   - env: TARGET=i686-unknown-linux-gnu
-  - env: TARGET=i686-unknown-linux-musl
   - env: TARGET=x86_64-unknown-linux-gnu
   - env: TARGET=x86_64-unknown-linux-musl
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,42 +1,92 @@
+# Based on the "trust" template v0.1.1
+# https://github.com/japaric/trust/tree/v0.1.1
+
+dist: trusty
 language: rust
-sudo: false
+services: docker
+sudo: required
 
 cache: cargo
+before_cache:
+- chmod -R a+r $HOME/.cargo
 
-rust:
-  - stable
-  - nightly
+env:
+  global:
+  - CRATE_NAME=mdbook
+  - secure: DPzSRXyfRIVTibv1wOKFeGekXlL8sumGEZxpeq911MpLlrndOKmOo5Ibi3JD8fbUOsE9A/5spj4B2KQNjhbplH+Cp26oEikjuNAA6cA/b2+/TMoC3i0klAYpVopBBV3FFna0gLP+q6t6fzG2v9TJrvmmVav6KVX6ylPNvD/LoReCjrkpgLIQuAQ6dSQNor9uV+EVt4plKhhkiS28DlYdgmTvNb5g4dzOhs8hoWty72J765VYWEDDC8qXn6N9GyrhsC3dhjASGn+1QDSCADYdbG9nrRlb4CZhrfcgOnHhAFva363kshg9HtCphigMgQy2oZXk4nLWK90/HuaPPkVj+N/lpIYjtiHOunToZJfIb0MWzyVI+7+I7WR6n6XbhLCPMe/sPXHHQ3HhQhZZ9xv7CDx9IkYJQBcF3LC+9kzJRi4QT0UTqrxcO3ncgXwvholP8Vg2KKPqFcbuyLPzbvr/o8zIilvLUFAEoDPfTEwSAC4BCzaGkFQVWzhWkgw8Pe1ckOEYFkZ0VLBuCpEiz+x45sbBL1SnnO5xhpjmdc572ZyW7ZmAABw1VfiWhhBWg4WGSf8lLnDHhNA36Qon34pnME/xpJQtWoo7ZZkkzvzYP/oW88/0UIMWDSOYKz7MijXlbNUggwAwUhrLzXDuB71HUKfPreFubfUxbOpu+OtTcOQ=
 
-os:
-  - linux
-  - osx
+matrix:
+  include:
+  # Android
+  - env: TARGET=arm-linux-androideabi DISABLE_TESTS=1
+
+  # Linux
+  - env: TARGET=aarch64-unknown-linux-gnu
+  - env: TARGET=arm-unknown-linux-gnueabi
+  - env: TARGET=i686-unknown-linux-gnu
+  - env: TARGET=i686-unknown-linux-musl
+  - env: TARGET=x86_64-unknown-linux-gnu
+  - env: TARGET=x86_64-unknown-linux-musl
+
+  # Mac
+  - env: TARGET=i686-apple-darwin
+    os: osx
+  - env: TARGET=x86_64-apple-darwin
+    os: osx
+
+  # BSD
+  - env: TARGET=i686-unknown-freebsd DISABLE_TESTS=1
+  - env: TARGET=x86_64-unknown-freebsd DISABLE_TESTS=1
+  - env: TARGET=x86_64-unknown-netbsd DISABLE_TESTS=1
+
+  # Other channels
+  - env: TARGET=x86_64-unknown-linux-gnu
+    rust: beta
+  - env: TARGET=x86_64-apple-darwin
+    os: osx
+    rust: beta
+  - env: TARGET=x86_64-unknown-linux-gnu
+    rust: nightly
+  - env: TARGET=x86_64-apple-darwin
+    os: osx
+    rust: nightly
+
+before_install:
+- set -e
+- rustup self update
+
+install:
+- sh ci/install.sh
+- source ~/.cargo/env || true
 
 script:
-  - cargo build --verbose
-  - cargo test --verbose
+- bash ci/script.sh
 
 after_success:
-  # Deploy the docs if the commit is on master
-  - test "$TRAVIS_PULL_REQUEST" == "false" &&
-    test "$TRAVIS_BRANCH" == "master" &&
-    test "$TRAVIS_RUST_VERSION" == "stable" &&
-    npm install stylus nib &&
-    bash ci/deploy.sh
+- test "$TRAVIS_PULL_REQUEST" == "false" && 
+  test "$TRAVIS_BRANCH" == "master" && 
+  test "$TRAVIS_RUST_VERSION" == "stable" && 
+  npm install stylus nib && 
+  bash ci/github_pages.sh
 
 before_deploy:
-  # Script to create packages from the build artefacts to upload to GitHub
-  - bash ci/before_deploy.sh
+- sh ci/before_deploy.sh
 
 deploy:
-  provider: releases
   api_key:
-    secure: Z1k7WqX7z+tT4+SzTh4tBBzf11VaADB4AWuEczHtylaEb/0hRs8gaiHCNSVHm/QTp0QPWQR2Vw7uKMhVuxG7I8X7h31j3A7ulYBh/iVk0DVIrtrn2Q4WOED9CpoXLuLtk2nxo9MBViFW7mw4nJe9H2Tn9o/9oEYBuwzekvW5mh4muqUuCVTr8eQVYbs3jbC9pQy5oYjOLeUnlL9Cey5VN/nAhzAtyFP+6lIMri0PKit4JtkFou/O1MEpFYlP3VGC2lFiWuByocPKBT/L45FecS9qoHq+i6+ZCPDH2eu46nuYsDbLKAkPdGvf1MdPBPwoj0vSnZbgaTisQ4hIoBngQQQPZlPaGtcdd6g6asxSfnbA9cQhClI5oZJmg+ksxQE+peE8pnbmZ10Ix0PpIkkfWdQeMdUUCQarOTkTK54Munw+X+kp1lH19j6+krQPLBYr95fPRd4b5tWsJD2+pb/UOYFEEJxMNoUHyLCrtdCO7imOwrSUcv51+Z8UudqfPpKQeszrJcntL4owip35r3sF5TsE9YfW5qssLC164IylvP32y1AcfL1jqg8b+zrqLZKanjvDOJ1dtHHuwKqxcwf7PhAf0YjAtVSH9OIYcDzmDa0EMLrq7EK0fs6NAeb5qt6CML7pZrRS3fmOxN53Fbmj81qm6TmjQjDe4dmZlELgNow=
-  file: ${PROJECT_NAME}-${TRAVIS_TAG}-${TRAVIS_OS_NAME}.tar.gz
-  # don't delete the artifacts from previous phases
-  skip_cleanup: true
+  - secure: cURRWBr034iqBz/ifD7uOunBfNR30YxIXfgLX0osWz+iafkVbhDGYYz9sBmRraqO2P7L2koEXMADVb/md1kI2+ykiq/ml+l9zuEAZPVmvSGUN7ZD+7s+lu3l5OBPG5z175T+b2q2q2m8XVR7TW20ra4QbE0bq06KAoOyjSgQVBTSCYsL9uTsGwiVRMEqqJT/BmKhKJNkpGsTKyBSKkOXvfeAAbE260vXUDEN9TYdJ3fvteRrpwLX56ee64gIZUq0RjDc4SKIEqilM6iUtNMvurqaewYNGkiXKRruV6BPCHxEHo6NNT46kOJLBJTf7gZw//dWhSoWpg9P0gdAnPWm407kSa3F7aJ1eRShAFQ4BLyfz9efTqm+jP3fOp7Mm7igSh9w6caSRuOnSsUf5+raRQ8E5Y9HsWGzzpZQk24Fx9EGZ04EeDSdpZAFz+jcbMpHf8t2p4CEx0CCNwYvKx6EydMKbMF5QteQ8SQkXNLhv7Rz2OgtXWYZPRVCMfQfOplsi2InsLCrQxTgwh+6u654SqVSgaHG+IncEAxBrdWy4rHcg7qereUcKfcY3k96vaDxdn/T2c00Ig0aNFR91YnixGMd6J6tQgDcRK9jh6fUm1CCBE9hT+pNUmtgYKuWBoLZexUZFFnfuBed0WciBot1bGDDamndqKq0jJiAzg+GMHk=
+  file_glob: true
+  file: "$CRATE_NAME-$TRAVIS_TAG-$TARGET.*"
   on:
-    condition: $TRAVIS_RUST_VERSION = stable
+    condition: "$TRAVIS_RUST_VERSION = stable"
     tags: true
+  provider: releases
+  skip_cleanup: true
+
+branches:
+  only:
+  - "/^v\\d+\\.\\d+\\.\\d+.*$/"
+  - master
 
 notifications:
   email:

--- a/.travis.yml
+++ b/.travis.yml
@@ -63,11 +63,7 @@ script:
 - bash ci/script.sh
 
 after_success:
-- test "$TRAVIS_PULL_REQUEST" == "false" && 
-  test "$TRAVIS_BRANCH" == "master" && 
-  test "$TRAVIS_RUST_VERSION" == "stable" && 
-  npm install stylus nib && 
-  bash ci/github_pages.sh
+- bash ci/github_pages.sh
 
 before_deploy:
 - sh ci/before_deploy.sh

--- a/ci/github_pages.sh
+++ b/ci/github_pages.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# Deploys the `book-example` to GitHub Pages
 
 # Exit on error or variable unset
 set -o errexit -o nounset

--- a/ci/github_pages.sh
+++ b/ci/github_pages.sh
@@ -1,8 +1,17 @@
 #!/bin/bash
 # Deploys the `book-example` to GitHub Pages
 
-# Exit on error or variable unset
-set -o errexit -o nounset
+set -ex
+
+# Only run this on the master branch for stable
+if [ "$TRAVIS_PULL_REQUEST" != "false" ] || 
+   [ "$TRAVIS_BRANCH" != "master" ] ||
+   [ "$TRAVIS_RUST_VERSION" != "stable" ]; then
+   exit 0
+fi
+
+# Make sure we have the css dependencies
+npm install stylus nib 
 
 NC='\033[39m'
 CYAN='\033[36m'
@@ -11,23 +20,20 @@ GREEN='\033[32m'
 rev=$(git rev-parse --short HEAD)
 
 echo -e "${CYAN}Running cargo doc${NC}"
-# Run cargo doc
-cargo doc
+cargo doc --features regenerate-css
 
 echo -e "${CYAN}Running mdbook build${NC}"
-# Run mdbook to generate the book
 target/"$TARGET"/debug/mdbook build book-example/
 
 echo -e "${CYAN}Copying book to target/doc${NC}"
-# Copy files from rendered book to doc root
 cp -R book-example/book/* target/doc/
 
 cd target/doc
 
 echo -e "${CYAN}Initializing Git${NC}"
 git init
-git config user.name "Mathieu David"
-git config user.email "mathieudavid@mathieudavid.org"
+git config user.name "Michael Bryan"
+git config user.email "michaelfbryan@gmail.com"
 
 git remote add upstream "https://$GH_TOKEN@github.com/rust-lang-nursery/mdBook.git"
 git fetch upstream
@@ -40,4 +46,4 @@ git add -A .
 git commit -m "rebuild pages at ${rev}"
 git push -q upstream HEAD:gh-pages
 
-echo -e "${GREEN}Deployement done${NC}"
+echo -e "${GREEN}Deployed docs to GitHub Pages${NC}"

--- a/ci/install.sh
+++ b/ci/install.sh
@@ -1,0 +1,47 @@
+set -ex
+
+main() {
+    local target=
+    if [ $TRAVIS_OS_NAME = linux ]; then
+        target=x86_64-unknown-linux-musl
+        sort=sort
+    else
+        target=x86_64-apple-darwin
+        sort=gsort  # for `sort --sort-version`, from brew's coreutils.
+    fi
+
+    # Builds for iOS are done on OSX, but require the specific target to be
+    # installed.
+    case $TARGET in
+        aarch64-apple-ios)
+            rustup target install aarch64-apple-ios
+            ;;
+        armv7-apple-ios)
+            rustup target install armv7-apple-ios
+            ;;
+        armv7s-apple-ios)
+            rustup target install armv7s-apple-ios
+            ;;
+        i386-apple-ios)
+            rustup target install i386-apple-ios
+            ;;
+        x86_64-apple-ios)
+            rustup target install x86_64-apple-ios
+            ;;
+    esac
+
+    # This fetches latest stable release
+    local tag=$(git ls-remote --tags --refs --exit-code https://github.com/japaric/cross \
+                       | cut -d/ -f3 \
+                       | grep -E '^v[0.1.0-9.]+$' \
+                       | $sort --version-sort \
+                       | tail -n1)
+    curl -LSfs https://japaric.github.io/trust/install.sh | \
+        sh -s -- \
+           --force \
+           --git japaric/cross \
+           --tag $tag \
+           --target $target
+}
+
+main

--- a/ci/script.sh
+++ b/ci/script.sh
@@ -1,0 +1,21 @@
+# This script takes care of testing your crate
+
+set -ex
+
+# TODO This is the "test phase", tweak it as you see fit
+main() {
+    cross build --target $TARGET
+    cross build --target $TARGET --release
+
+    if [ ! -z $DISABLE_TESTS ]; then
+        return
+    fi
+
+    cross test --target $TARGET
+    cross test --target $TARGET --release
+}
+
+# we don't run the "test phase" when doing deploys
+if [ -z $TRAVIS_TAG ]; then
+    main
+fi


### PR DESCRIPTION
The last several releases haven't uploaded binaries. I've updated `.travis.yml` to use japaric/trust to configure travis, plus created a new Personal Access Token so releases should hopefully work again.

Testing on the `beta` channel was previously deactivated because there was a compiler issue (see #490 and #492). It should be working again so I've re-enabled `beta` testing.

Because I've added a bunch more targets the CI build times may be adversely affected... I'll see how it goes, but may end up removing a couple targets if it becomes a problem.

---

I'm not sure what we're going to do about Appveyor. It's been broken ever since we moved mdbook to the nursery, meaning we're not currently testing or generating release binaries for windows. The easiest way to deal with it would be to tell Appveyor that I can look after `rust-lang-nursery/mdBook` and I can deal with it from there, but @budziq [mentioned] that this may not be an overly straightforward process.

[mentioned]: https://github.com/rust-lang-nursery/mdBook/issues/482#issuecomment-345529809