### PR TITLE
Roll back iron version in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,8 +38,8 @@ time = { version = "0.1.34", optional = true }
 crossbeam = { version = "0.3", optional = true }
 
 # Serve feature
-iron = { version = "0.6", optional = true }
-staticfile = { version = "0.5", optional = true }
+iron = { version = "0.5", optional = true }
+staticfile = { version = "0.4", optional = true }
 ws = { version = "0.7", optional = true}
 
 [build-dependencies]

--- a/ci/github_pages.sh
+++ b/ci/github_pages.sh
@@ -43,7 +43,7 @@ git reset upstream/gh-pages --quiet
 touch .
 
 echo -e "${CYAN}Pushing changes to gh-pages${NC}"
-git add -A . --quiet
+git add -A . 
 git commit -m "rebuild pages at ${rev}" --quiet
 git push -q upstream HEAD:gh-pages --quiet
 


### PR DESCRIPTION
It looks like staticfile `0.5` isn't compatible with iron `0.6` because the `0.6` version of `iron::Handler` isn't implemented for `staticfile::Static` (0.5). To work around this I'm rolling the versions back one.

I've also fixed an issue in the `github_pages.sh` script where `--quiet` isn't a valid argument to `git add`.