### PR TITLE
Implement partial include of source files

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ memchr = "2.0.1"
 open = "1.1"
 regex = "0.2.1"
 tempdir = "0.3.4"
+itertools = "0.7.4"
 
 # Watch feature
 notify = { version = "4.0", optional = true }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -96,6 +96,7 @@
 #[macro_use]
 extern crate error_chain;
 extern crate handlebars;
+extern crate itertools;
 #[macro_use]
 extern crate lazy_static;
 #[macro_use]

--- a/src/preprocess/links.rs
+++ b/src/preprocess/links.rs
@@ -2,7 +2,7 @@ use std::ops::{Range, RangeFrom, RangeTo, RangeFull};
 use std::path::{Path, PathBuf};
 use regex::{CaptureMatches, Captures, Regex};
 use utils::fs::file_to_string;
-use utils::string::take_lines;
+use utils::take_lines;
 use errors::*;
 
 const ESCAPE_CHAR: char = '\\';

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -1,10 +1,11 @@
 pub mod fs;
-pub mod string;
+mod string;
 
 use pulldown_cmark::{html, Event, Options, Parser, Tag, OPTION_ENABLE_FOOTNOTES,
                      OPTION_ENABLE_TABLES};
 use std::borrow::Cow;
 
+pub use self::string::{RangeArgument, take_lines};
 
 ///
 ///

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -1,4 +1,5 @@
 pub mod fs;
+pub mod string;
 
 use pulldown_cmark::{html, Event, Options, Parser, Tag, OPTION_ENABLE_FOOTNOTES,
                      OPTION_ENABLE_TABLES};

--- a/src/utils/string.rs
+++ b/src/utils/string.rs
@@ -2,7 +2,8 @@ use std::ops::{Range, RangeFrom, RangeFull, RangeTo};
 use itertools::Itertools;
 
 // This trait is already contained in the standard lib, however it is unstable.
-// When the feature will stabilize, pls remove!
+// TODO: Remove when the `collections_range` feature stabilises
+// (https://github.com/rust-lang/rust/issues/30877)
 pub trait RangeArgument<T: ?Sized> {
     fn start(&self) -> Option<&T>;
     fn end(&self) -> Option<&T>;

--- a/src/utils/string.rs
+++ b/src/utils/string.rs
@@ -1,0 +1,69 @@
+use std::ops::{Range, RangeFrom, RangeFull, RangeTo};
+use itertools::Itertools;
+
+// This trait is already contained in the standard lib, however it is unstable.
+// When the feature will stabilize, pls remove!
+pub trait RangeArgument<T: ?Sized> {
+    fn start(&self) -> Option<&T>;
+    fn end(&self) -> Option<&T>;
+}
+
+impl<T: ?Sized> RangeArgument<T> for RangeFull {
+    fn start(&self) -> Option<&T> {
+        None
+    }
+    fn end(&self) -> Option<&T> {
+        None
+    }
+}
+
+impl<T> RangeArgument<T> for RangeFrom<T> {
+    fn start(&self) -> Option<&T> {
+        Some(&self.start)
+    }
+    fn end(&self) -> Option<&T> {
+        None
+    }
+}
+
+impl<T> RangeArgument<T> for RangeTo<T> {
+    fn start(&self) -> Option<&T> {
+        None
+    }
+    fn end(&self) -> Option<&T> {
+        Some(&self.end)
+    }
+}
+
+impl<T> RangeArgument<T> for Range<T> {
+    fn start(&self) -> Option<&T> {
+        Some(&self.start)
+    }
+    fn end(&self) -> Option<&T> {
+        Some(&self.end)
+    }
+}
+
+/// Take a range of lines from a string.
+pub fn take_lines<R: RangeArgument<usize>>(s: &str, range: R) -> String {
+    let start = *range.start().unwrap_or(&0);
+    let mut lines = s.lines().skip(start);
+    match range.end() {
+        Some(&end) => lines.take(end).join("\n"),
+        None => lines.join("\n"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::take_lines;
+
+    #[test]
+    fn take_lines_test() {
+        let s = "Lorem\nipsum\ndolor\nsit\namet";
+        assert_eq!(take_lines(s, 0..3), "Lorem\nipsum\ndolor");
+        assert_eq!(take_lines(s, 3..), "sit\namet");
+        assert_eq!(take_lines(s, ..3), "Lorem\nipsum\ndolor");
+        assert_eq!(take_lines(s, ..), s);
+    }
+}


### PR DESCRIPTION
The macro `{{include some_file}}` accepts now optional line number arguments, s.t. the specified line range is included. The following forms are supported:

* `{{include some_file::}}` is equivalent to `{{include some_file}}`
* `{{include some_file:from:}}` includes lines [from, infinity)
* `{{include some_file::to}}` includes lines [0, to]
* `{{include some_file:from:to}}` includes lines [from, to]

This is useful when including files containing full source code.