### PR TITLE
Fixed a regression introduced by previous refactoring of `mdbook watch`

### DIFF
--- a/src/bin/mdbook.rs
+++ b/src/bin/mdbook.rs
@@ -3,6 +3,7 @@ extern crate clap;
 extern crate chrono;
 extern crate env_logger;
 extern crate error_chain;
+#[macro_use]
 extern crate log;
 extern crate mdbook;
 extern crate open;

--- a/src/bin/watch.rs
+++ b/src/bin/watch.rs
@@ -74,7 +74,7 @@ where
 
     println!("\nListening for changes...\n");
 
-    for event in rx.recv() {
+    for event in rx.iter() {
         match event {
             Create(path) | Write(path) | Remove(path) | Rename(_, path) => {
                 closure(&path, &book.root);


### PR DESCRIPTION
The `trigger_on_change()` was previously only executing once because we were "iterating" over the result of `rx.recv()` (a `Result<Event>`), instead of the iterator, [`rx.iter()`]. 

```diff
     println!("\nListening for changes...\n");
 
-    for event in rx.recv() {
+    for event in rx.iter() {
         match event {
             Create(path) | Write(path) | Remove(path) | Rename(_, path) => {
```

This also fixes an issue where the livereload wasn't being re-set on consecutive builds in `mdbook serve`.

[`rx.iter()`]: https://doc.rust-lang.org/std/sync/mpsc/struct.Receiver.html#method.iter
  