### PR TITLE
Prohibit 'print.md' files

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -128,6 +128,8 @@ pub use renderer::Renderer;
 
 /// The error types used through out this crate.
 pub mod errors {
+    use std::path::PathBuf;
+
     error_chain!{
         foreign_links {
             Io(::std::io::Error);
@@ -147,9 +149,9 @@ pub mod errors {
                 display("Error at line {}, column {}: {}", line, col, message)
             }
 
-            ReservedFilenameError(message: String, filename: String) {
-                description("A reserved filename error")
-                display("Error while processing {}: {}", filename, message)
+            ReservedFilenameError(filename: PathBuf) {
+                description("Reserved Filename")
+                display("{} is reserved for internal use", filename.display())
             }
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -146,6 +146,11 @@ pub mod errors {
                 description("A SUMMARY.md parsing error")
                 display("Error at line {}, column {}: {}", line, col, message)
             }
+
+            ReservedFilenameError(message: String, filename: String) {
+                description("A reserved filename error")
+                display("Error while processing {}: {}", filename, message)
+            }
         }
     }
 

--- a/src/renderer/html_handlebars/hbs_renderer.rs
+++ b/src/renderer/html_handlebars/hbs_renderer.rs
@@ -54,6 +54,14 @@ impl HtmlHandlebars {
                                                                            to str")
                                                        })?;
 
+                // "print.html" is used for the print page.
+                if path == "print.md" {
+                    bail!(ErrorKind::ReservedFilenameError(
+                        "Filename print.md is reserved for internal usage.".to_string(),
+                        path.to_string())
+                    );
+                };
+
                 // Non-lexical lifetimes needed :'(
                 let title: String;
                 {

--- a/src/renderer/html_handlebars/hbs_renderer.rs
+++ b/src/renderer/html_handlebars/hbs_renderer.rs
@@ -55,11 +55,8 @@ impl HtmlHandlebars {
                                                        })?;
 
                 // "print.html" is used for the print page.
-                if path == "print.md" {
-                    bail!(ErrorKind::ReservedFilenameError(
-                        "Filename print.md is reserved for internal usage.".to_string(),
-                        path.to_string())
-                    );
+                if ch.path == Path::new("print.md") {
+                    bail!(ErrorKind::ReservedFilenameError(ch.path.clone()));
                 };
 
                 // Non-lexical lifetimes needed :'(


### PR DESCRIPTION
Fix #258 by emmiting an error whenever an mdBook contains a `print.md` file in its root.