### PR TITLE
Add option to disable section label in html

### DIFF
--- a/book-example/src/format/config.md
+++ b/book-example/src/format/config.md
@@ -84,6 +84,9 @@ The following configuration options are available:
   removing the current behaviour, you can specify a set of javascript files
   that will be loaded alongside the default one.
 - **playpen:** A subtable for configuring various playpen settings.
+- **no-section-label**: mdBook by defaults adds section label in table of
+  contents column. For example, "1.", "2.1". Set this option to true to
+  disable those labels. Defaults to `false`.
 
 **book.toml**
 ```toml

--- a/src/config.rs
+++ b/src/config.rs
@@ -326,6 +326,7 @@ pub struct HtmlConfig {
     /// This config item *should not be edited* by the end user.
     #[doc(hidden)]
     pub livereload_url: Option<String>,
+    pub no_section_label: bool,
 }
 
 /// Configuration for tweaking how the the HTML renderer handles the playpen.

--- a/src/renderer/html_handlebars/hbs_renderer.rs
+++ b/src/renderer/html_handlebars/hbs_renderer.rs
@@ -239,8 +239,8 @@ impl HtmlHandlebars {
                     json!(utils::fs::path_to_root(Path::new("print.md"))));
     }
 
-    fn register_hbs_helpers(&self, handlebars: &mut Handlebars) {
-        handlebars.register_helper("toc", Box::new(helpers::toc::RenderToc));
+    fn register_hbs_helpers(&self, handlebars: &mut Handlebars, html_config: &HtmlConfig) {
+        handlebars.register_helper("toc", Box::new(helpers::toc::RenderToc {no_section_label: html_config.no_section_label}));
         handlebars.register_helper("previous", Box::new(helpers::navigation::previous));
         handlebars.register_helper("next", Box::new(helpers::navigation::next));
     }
@@ -307,7 +307,7 @@ impl Renderer for HtmlHandlebars {
         )?;
 
         debug!("[*]: Register handlebars helpers");
-        self.register_hbs_helpers(&mut handlebars);
+        self.register_hbs_helpers(&mut handlebars, &html_config);
 
         let mut data = make_data(&ctx.root, &book, &ctx.config, &html_config)?;
 

--- a/src/renderer/html_handlebars/helpers/toc.rs
+++ b/src/renderer/html_handlebars/helpers/toc.rs
@@ -7,7 +7,9 @@ use pulldown_cmark::{html, Event, Parser, Tag};
 
 // Handlebars helper to construct TOC
 #[derive(Clone, Copy)]
-pub struct RenderToc;
+pub struct RenderToc {
+    pub no_section_label: bool
+}
 
 impl HelperDef for RenderToc {
     fn call(&self, _h: &Helper, _: &Handlebars, rc: &mut RenderContext) -> Result<(), RenderError> {
@@ -91,11 +93,13 @@ impl HelperDef for RenderToc {
                 false
             };
 
-            // Section does not necessarily exist
-            if let Some(section) = item.get("section") {
-                rc.writer.write_all(b"<strong>")?;
-                rc.writer.write_all(section.as_bytes())?;
-                rc.writer.write_all(b"</strong> ")?;
+            if !self.no_section_label {
+                // Section does not necessarily exist
+                if let Some(section) = item.get("section") {
+                    rc.writer.write_all(b"<strong>")?;
+                    rc.writer.write_all(section.as_bytes())?;
+                    rc.writer.write_all(b"</strong> ")?;
+                }
             }
 
             if let Some(name) = item.get("name") {


### PR DESCRIPTION
Allow user to disable section label in the html.

User may have custom rules for naming their sections in 'SUMMARY.md', e.g. "Chapter 0", "Chapter 1.1". By default, it would show up as "1. Chapter 0", and "2.1 Chapter 1.1". In this case, we may provide an option to hide the auto generated labels.

Just saw #504 for similar goal. The change here is a bit lightweighted, which controls html output only.