### PR TITLE
Write RenderContext to the subprocess' stdin again

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,6 @@ open = "1.1"
 regex = "0.2.1"
 tempdir = "0.3.4"
 itertools = "0.7.4"
-tempfile = "2.2.0"
 shlex = "0.1.1"
 toml-query = "0.6"
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -111,7 +111,6 @@ extern crate serde_derive;
 extern crate serde_json;
 extern crate shlex;
 extern crate tempdir;
-extern crate tempfile;
 extern crate toml;
 extern crate toml_query;
 

--- a/tests/alternate_backends.rs
+++ b/tests/alternate_backends.rs
@@ -3,9 +3,11 @@
 extern crate mdbook;
 extern crate tempdir;
 
+use std::fs::File;
 use tempdir::TempDir;
 use mdbook::config::Config;
 use mdbook::MDBook;
+use mdbook::renderer::RenderContext;
 
 #[test]
 fn passing_alternate_backend() {
@@ -26,6 +28,22 @@ fn alternate_backend_with_arguments() {
     let (md, _temp) = dummy_book_with_backend("arguments", "echo Hello World!");
 
     md.build().unwrap();
+}
+
+#[test]
+fn backends_receive_render_context_via_stdin() {
+    let temp = TempDir::new("output").unwrap();
+    let out_file = temp.path().join("out.txt");
+    let cmd = format!("tee {}", out_file.display());
+
+    let (md, _temp) = dummy_book_with_backend("cat-to-file", &cmd);
+
+    assert!(!out_file.exists());
+    md.build().unwrap();
+    assert!(out_file.exists());
+
+    let got = RenderContext::from_json(File::open(&out_file).unwrap());
+    assert!(got.is_ok());
 }
 
 fn dummy_book_with_backend(name: &str, command: &str) -> (MDBook, TempDir) {


### PR DESCRIPTION
Previously I was writing the `RenderContext` to a temporary file and then hooking it up to the subprocess' `stdin`, but for some reason this didn't work as planned because the child process wasn't receiving anything. This reverts that earlier idea and just writes to `stdin` directly.