### PR TITLE
Meta theme color

### DIFF
--- a/src/theme/book.js
+++ b/src/theme/book.js
@@ -161,6 +161,10 @@ $( document ).ready(function() {
             ace_theme = "ace/theme/dawn";
         }
 
+        setTimeout(function() {
+            document.querySelector('meta[name="theme-color"]').content = getComputedStyle(document.body).backgroundColor;
+        }, 1);
+
         if (window.ace && window.editors) {
             window.editors.forEach(function(editor) {
                 editor.setTheme(ace_theme);

--- a/src/theme/index.hbs
+++ b/src/theme/index.hbs
@@ -6,6 +6,7 @@
         <meta content="text/html; charset=utf-8" http-equiv="Content-Type">
         <meta name="description" content="{{ description }}">
         <meta name="viewport" content="width=device-width, initial-scale=1">
+        <meta name="theme-color" content="#ffffff" />
 
         <base href="{{ path_to_root }}">
 


### PR DESCRIPTION
Makes the browser chrome match the selected theme (to avoid having a bright white toolbar when you chose a dark theme - also looks nice). Currently only supported in Chrome for Android (left is before, right is with this patch).

<img src="https://user-images.githubusercontent.com/2109702/34969353-b35cd734-fa6e-11e7-89a0-38c0d81aec73.png" width=200> <img src="https://user-images.githubusercontent.com/2109702/34969350-b2fc8c30-fa6e-11e7-8f03-da9b34a164e4.png" width=200>

<img src="https://user-images.githubusercontent.com/2109702/34969354-b378cdf4-fa6e-11e7-891e-e79cccbe00af.png" width=200> <img src="https://user-images.githubusercontent.com/2109702/34969351-b31bf566-fa6e-11e7-94a8-249d7ce1d912.png" width=200>