### PR TITLE
Temporarily ignore OSX jobs on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,10 +28,10 @@ matrix:
   - env: TARGET=x86_64-unknown-linux-musl
 
   # Mac
-  - env: TARGET=i686-apple-darwin
-    os: osx
-  - env: TARGET=x86_64-apple-darwin
-    os: osx
+  # - env: TARGET=i686-apple-darwin
+  #   os: osx
+  # - env: TARGET=x86_64-apple-darwin
+  #   os: osx
 
   # BSD
   - env: TARGET=i686-unknown-freebsd DISABLE_TESTS=1
@@ -41,14 +41,14 @@ matrix:
   # Other channels
   - env: TARGET=x86_64-unknown-linux-gnu
     rust: beta
-  - env: TARGET=x86_64-apple-darwin
-    os: osx
-    rust: beta
+  # - env: TARGET=x86_64-apple-darwin
+  #   os: osx
+  #   rust: beta
   - env: TARGET=x86_64-unknown-linux-gnu
     rust: nightly
-  - env: TARGET=x86_64-apple-darwin
-    os: osx
-    rust: nightly
+  # - env: TARGET=x86_64-apple-darwin
+  #   os: osx
+  #   rust: nightly
 
 before_install:
 - set -e

--- a/src/renderer/mod.rs
+++ b/src/renderer/mod.rs
@@ -15,6 +15,7 @@ pub use self::html_handlebars::HtmlHandlebars;
 
 mod html_handlebars;
 
+use std::fs;
 use std::io::Read;
 use std::path::PathBuf;
 use std::process::{Command, Stdio};
@@ -151,6 +152,8 @@ impl Renderer for CmdRenderer {
 
     fn render(&self, ctx: &RenderContext) -> Result<()> {
         info!("Invoking the \"{}\" renderer", self.cmd);
+
+        let _ = fs::create_dir_all(&ctx.destination);
 
         let mut child = self.compose_command()?
             .stdin(Stdio::piped())


### PR DESCRIPTION
For the past couple days it looks like all OSX jobs have been "waiting to be queued" indefinitely. I'm going to disable the CI jobs temporarily so GitHub doesn't erroneously show PRs as failing (because travis kills the job after 12 or so hours of waiting).