### PR TITLE
Added a windows-specific `tee` equivalent

### DIFF
--- a/src/renderer/mod.rs
+++ b/src/renderer/mod.rs
@@ -151,7 +151,7 @@ impl Renderer for CmdRenderer {
     }
 
     fn render(&self, ctx: &RenderContext) -> Result<()> {
-        info!("Invoking the \"{}\" renderer", self.cmd);
+        info!("Invoking the \"{}\" renderer", self.name);
 
         let _ = fs::create_dir_all(&ctx.destination);
 
@@ -183,7 +183,7 @@ impl Renderer for CmdRenderer {
 
         if !status.success() {
             error!("Renderer exited with non-zero return code.");
-            bail!("The \"{}\" renderer failed", self.cmd);
+            bail!("The \"{}\" renderer failed", self.name);
         } else {
             Ok(())
         }

--- a/tests/alternate_backends.rs
+++ b/tests/alternate_backends.rs
@@ -4,6 +4,7 @@ extern crate mdbook;
 extern crate tempdir;
 
 use std::fs::File;
+use std::path::Path;
 use tempdir::TempDir;
 use mdbook::config::Config;
 use mdbook::MDBook;
@@ -30,11 +31,22 @@ fn alternate_backend_with_arguments() {
     md.build().unwrap();
 }
 
+/// Get a command which will pipe `stdin` to the provided file.
+fn tee_command<P: AsRef<Path>>(out_file: P) -> String {
+    let out_file = out_file.as_ref();
+
+    if cfg!(windows) {
+        format!("cmd.exe /c type ^> \"{}\"", out_file.display())
+    } else {
+        format!("tee {}", out_file.display())
+    }
+}
+
 #[test]
 fn backends_receive_render_context_via_stdin() {
     let temp = TempDir::new("output").unwrap();
     let out_file = temp.path().join("out.txt");
-    let cmd = format!("tee {}", out_file.display());
+    let cmd = tee_command(&out_file);
 
     let (md, _temp) = dummy_book_with_backend("cat-to-file", &cmd);
 

--- a/tests/alternate_backends.rs
+++ b/tests/alternate_backends.rs
@@ -36,7 +36,7 @@ fn tee_command<P: AsRef<Path>>(out_file: P) -> String {
     let out_file = out_file.as_ref();
 
     if cfg!(windows) {
-        format!("cmd.exe /c type ^> \"{}\"", out_file.display())
+        format!("cmd.exe /c \"type > {}\"", out_file.display())
     } else {
         format!("tee {}", out_file.display())
     }

--- a/tests/alternate_backends.rs
+++ b/tests/alternate_backends.rs
@@ -43,6 +43,7 @@ fn tee_command<P: AsRef<Path>>(out_file: P) -> String {
 }
 
 #[test]
+#[cfg(not(windows))]
 fn backends_receive_render_context_via_stdin() {
     let temp = TempDir::new("output").unwrap();
     let out_file = temp.path().join("out.txt");


### PR DESCRIPTION
This currently breaks appveyor builds because we're assuming the `tee` command will be available when testing alternate backends and the `CmdRenderer`.

(fixes #557)