### PR TITLE
Recursively apply replace_all() when running the links preprocessor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ book-test
 book-example/book
 
 .vscode
+tests/dummy_book/book/
+

--- a/src/preprocess/links.rs
+++ b/src/preprocess/links.rs
@@ -1,4 +1,4 @@
-use std::ops::{Range, RangeFrom, RangeTo, RangeFull};
+use std::ops::{Range, RangeFrom, RangeFull, RangeTo};
 use std::path::{Path, PathBuf};
 use regex::{CaptureMatches, Captures, Regex};
 use utils::fs::file_to_string;
@@ -26,38 +26,50 @@ impl Preprocessor for LinkPreprocessor {
     fn run(&self, ctx: &PreprocessorContext, book: &mut Book) -> Result<()> {
         let src_dir = ctx.root.join(&ctx.config.book.src);
 
-        for section in &mut book.sections {
-            match *section {
-                BookItem::Chapter(ref mut ch) => {
-                    let base = ch.path.parent()
-                        .map(|dir| src_dir.join(dir))
-                        .ok_or_else(|| String::from("Invalid bookitem path!"))?;
-                    let content = replace_all(&ch.content, base)?;
-                    ch.content = content
-                }
-                _ => {}
+        book.for_each_mut(|section: &mut BookItem| {
+            if let BookItem::Chapter(ref mut ch) = *section {
+                println!("Checking {}", ch);
+                let base = ch.path
+                    .parent()
+                    .map(|dir| src_dir.join(dir))
+                    .expect("All book items have a parent");
+
+                let content = replace_all(&ch.content, base);
+                ch.content = content;
             }
-        }
+        });
 
         Ok(())
     }
 }
 
-fn replace_all<P: AsRef<Path>>(s: &str, path: P) -> Result<String> {
+fn replace_all<P: AsRef<Path>>(s: &str, path: P) -> String {
     // When replacing one thing in a string by something with a different length,
     // the indices after that will not correspond,
     // we therefore have to store the difference to correct this
+    let path = path.as_ref();
     let mut previous_end_index = 0;
     let mut replaced = String::new();
 
     for playpen in find_links(s) {
+        println!("{} {:?}", path.display(), playpen);
         replaced.push_str(&s[previous_end_index..playpen.start_index]);
-        replaced.push_str(&playpen.render_with_path(&path)?);
-        previous_end_index = playpen.end_index;
+
+        match playpen.render_with_path(&path) {
+            Ok(new_content) => {
+                replaced.push_str(&new_content);
+            }
+            Err(e) => {
+                error!("Error updating \"{}\", {}", playpen.link_text, e);
+                // This should make sure we include the raw `{{# ... }}` snippet
+                // in the page content if there are any errors.
+                previous_end_index = playpen.start_index;
+            }
+        }
     }
 
     replaced.push_str(&s[previous_end_index..]);
-    Ok(replaced)
+    replaced
 }
 
 #[derive(PartialEq, Debug, Clone)]
@@ -76,18 +88,20 @@ fn parse_include_path(path: &str) -> LinkType<'static> {
     let start = parts.next().and_then(|s| s.parse::<usize>().ok());
     let end = parts.next().and_then(|s| s.parse::<usize>().ok());
     match start {
-        Some(start) => {
-            match end {
-                Some(end) => LinkType::IncludeRange(path, Range{ start: start, end: end}),
-                None => LinkType::IncludeRangeFrom(path, RangeFrom{ start: start }),
-            }
-        }
-        None => {
-            match end {
-                Some(end) => LinkType::IncludeRangeTo(path, RangeTo{ end: end }),
-                None => LinkType::IncludeRangeFull(path, RangeFull),
-            }
-        }
+        Some(start) => match end {
+            Some(end) => LinkType::IncludeRange(
+                path,
+                Range {
+                    start: start,
+                    end: end,
+                },
+            ),
+            None => LinkType::IncludeRangeFrom(path, RangeFrom { start: start }),
+        },
+        None => match end {
+            Some(end) => LinkType::IncludeRangeTo(path, RangeTo { end: end }),
+            None => LinkType::IncludeRangeFull(path, RangeFull),
+        },
     }
 }
 
@@ -113,20 +127,18 @@ impl<'a> Link<'a> {
                     _ => None,
                 }
             }
-            (Some(mat), None, None) if mat.as_str().starts_with(ESCAPE_CHAR) => Some(
-                LinkType::Escaped,
-            ),
+            (Some(mat), None, None) if mat.as_str().starts_with(ESCAPE_CHAR) => {
+                Some(LinkType::Escaped)
+            }
             _ => None,
         };
 
         link_type.and_then(|lnk| {
-            cap.get(0).map(|mat| {
-                Link {
-                    start_index: mat.start(),
-                    end_index: mat.end(),
-                    link: lnk,
-                    link_text: mat.as_str(),
-                }
+            cap.get(0).map(|mat| Link {
+                start_index: mat.start(),
+                end_index: mat.end(),
+                link: lnk,
+                link_text: mat.as_str(),
             })
         })
     }
@@ -136,37 +148,20 @@ impl<'a> Link<'a> {
         match self.link {
             // omit the escape char
             LinkType::Escaped => Ok((&self.link_text[1..]).to_owned()),
-            LinkType::IncludeRange(ref pat, ref range) => {
-                file_to_string(base.join(pat))
-                    .map(|s| take_lines(&s, range.clone()))
-                    .chain_err(|| {
-                        format!("Could not read file for link {}", self.link_text)
-                    })
-            }
-            LinkType::IncludeRangeFrom(ref pat, ref range) => {
-                file_to_string(base.join(pat))
-                    .map(|s| take_lines(&s, range.clone()))
-                    .chain_err(|| {
-                        format!("Could not read file for link {}", self.link_text)
-                    })
-            }
-            LinkType::IncludeRangeTo(ref pat, ref range) => {
-                file_to_string(base.join(pat))
-                    .map(|s| take_lines(&s, range.clone()))
-                    .chain_err(|| {
-                        format!("Could not read file for link {}", self.link_text)
-                    })
-            }
-            LinkType::IncludeRangeFull(ref pat, _) => {
-                file_to_string(base.join(pat))
-                    .chain_err(|| {
-                        format!("Could not read file for link {}", self.link_text)
-                    })
-            }
+            LinkType::IncludeRange(ref pat, ref range) => file_to_string(base.join(pat))
+                .map(|s| take_lines(&s, range.clone()))
+                .chain_err(|| format!("Could not read file for link {}", self.link_text)),
+            LinkType::IncludeRangeFrom(ref pat, ref range) => file_to_string(base.join(pat))
+                .map(|s| take_lines(&s, range.clone()))
+                .chain_err(|| format!("Could not read file for link {}", self.link_text)),
+            LinkType::IncludeRangeTo(ref pat, ref range) => file_to_string(base.join(pat))
+                .map(|s| take_lines(&s, range.clone()))
+                .chain_err(|| format!("Could not read file for link {}", self.link_text)),
+            LinkType::IncludeRangeFull(ref pat, _) => file_to_string(base.join(pat))
+                .chain_err(|| format!("Could not read file for link {}", self.link_text)),
             LinkType::Playpen(ref pat, ref attrs) => {
-                let contents = file_to_string(base.join(pat)).chain_err(|| {
-                    format!("Could not read file for link {}", self.link_text)
-                })?;
+                let contents = file_to_string(base.join(pat))
+                    .chain_err(|| format!("Could not read file for link {}", self.link_text))?;
                 let ftype = if !attrs.is_empty() { "rust," } else { "rust" };
                 Ok(format!(
                     "```{}{}\n{}\n```\n",
@@ -210,200 +205,242 @@ fn find_links(contents: &str) -> LinkIter {
     LinkIter(RE.captures_iter(contents))
 }
 
-// ---------------------------------------------------------------------------------
-//      Tests
-//
+#[cfg(test)]
+mod tests {
+    use super::*;
 
-#[test]
-fn test_find_links_no_link() {
-    let s = "Some random text without link...";
-    assert!(find_links(s).collect::<Vec<_>>() == vec![]);
-}
+    #[test]
+    fn test_find_links_no_link() {
+        let s = "Some random text without link...";
+        assert!(find_links(s).collect::<Vec<_>>() == vec![]);
+    }
 
-#[test]
-fn test_find_links_partial_link() {
-    let s = "Some random text with {{#playpen...";
-    assert!(find_links(s).collect::<Vec<_>>() == vec![]);
-    let s = "Some random text with {{#include...";
-    assert!(find_links(s).collect::<Vec<_>>() == vec![]);
-    let s = "Some random text with \\{{#include...";
-    assert!(find_links(s).collect::<Vec<_>>() == vec![]);
-}
+    #[test]
+    fn test_find_links_partial_link() {
+        let s = "Some random text with {{#playpen...";
+        assert!(find_links(s).collect::<Vec<_>>() == vec![]);
+        let s = "Some random text with {{#include...";
+        assert!(find_links(s).collect::<Vec<_>>() == vec![]);
+        let s = "Some random text with \\{{#include...";
+        assert!(find_links(s).collect::<Vec<_>>() == vec![]);
+    }
 
-#[test]
-fn test_find_links_empty_link() {
-    let s = "Some random text with {{#playpen}} and {{#playpen   }} {{}} {{#}}...";
-    assert!(find_links(s).collect::<Vec<_>>() == vec![]);
-}
+    #[test]
+    fn test_find_links_empty_link() {
+        let s = "Some random text with {{#playpen}} and {{#playpen   }} {{}} {{#}}...";
+        assert!(find_links(s).collect::<Vec<_>>() == vec![]);
+    }
 
-#[test]
-fn test_find_links_unknown_link_type() {
-    let s = "Some random text with {{#playpenz ar.rs}} and {{#incn}} {{baz}} {{#bar}}...";
-    assert!(find_links(s).collect::<Vec<_>>() == vec![]);
-}
+    #[test]
+    fn test_find_links_unknown_link_type() {
+        let s = "Some random text with {{#playpenz ar.rs}} and {{#incn}} {{baz}} {{#bar}}...";
+        assert!(find_links(s).collect::<Vec<_>>() == vec![]);
+    }
 
-#[test]
-fn test_find_links_simple_link() {
-    let s = "Some random text with {{#playpen file.rs}} and {{#playpen test.rs }}...";
+    #[test]
+    fn test_find_links_simple_link() {
+        let s = "Some random text with {{#playpen file.rs}} and {{#playpen test.rs }}...";
 
-    let res = find_links(s).collect::<Vec<_>>();
-    println!("\nOUTPUT: {:?}\n", res);
+        let res = find_links(s).collect::<Vec<_>>();
+        println!("\nOUTPUT: {:?}\n", res);
 
-    assert_eq!(res,
-               vec![Link {
-                        start_index: 22,
-                        end_index: 42,
-                        link: LinkType::Playpen(PathBuf::from("file.rs"), vec![]),
-                        link_text: "{{#playpen file.rs}}",
-                    },
-                    Link {
-                        start_index: 47,
-                        end_index: 68,
-                        link: LinkType::Playpen(PathBuf::from("test.rs"), vec![]),
-                        link_text: "{{#playpen test.rs }}",
-                    }]);
-}
+        assert_eq!(
+            res,
+            vec![
+                Link {
+                    start_index: 22,
+                    end_index: 42,
+                    link: LinkType::Playpen(PathBuf::from("file.rs"), vec![]),
+                    link_text: "{{#playpen file.rs}}",
+                },
+                Link {
+                    start_index: 47,
+                    end_index: 68,
+                    link: LinkType::Playpen(PathBuf::from("test.rs"), vec![]),
+                    link_text: "{{#playpen test.rs }}",
+                },
+            ]
+        );
+    }
 
-#[test]
-fn test_find_links_with_range() {
-    let s = "Some random text with {{#include file.rs:10:20}}...";
-    let res = find_links(s).collect::<Vec<_>>();
-    println!("\nOUTPUT: {:?}\n", res);
-    assert_eq!(
-        res,
-        vec![
+    #[test]
+    fn test_find_links_with_range() {
+        let s = "Some random text with {{#include file.rs:10:20}}...";
+        let res = find_links(s).collect::<Vec<_>>();
+        println!("\nOUTPUT: {:?}\n", res);
+        assert_eq!(
+            res,
+            vec![
+                Link {
+                    start_index: 22,
+                    end_index: 48,
+                    link: LinkType::IncludeRange(PathBuf::from("file.rs"), 10..20),
+                    link_text: "{{#include file.rs:10:20}}",
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn test_find_links_with_from_range() {
+        let s = "Some random text with {{#include file.rs:10:}}...";
+        let res = find_links(s).collect::<Vec<_>>();
+        println!("\nOUTPUT: {:?}\n", res);
+        assert_eq!(
+            res,
+            vec![
+                Link {
+                    start_index: 22,
+                    end_index: 46,
+                    link: LinkType::IncludeRangeFrom(PathBuf::from("file.rs"), 10..),
+                    link_text: "{{#include file.rs:10:}}",
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn test_find_links_with_to_range() {
+        let s = "Some random text with {{#include file.rs::20}}...";
+        let res = find_links(s).collect::<Vec<_>>();
+        println!("\nOUTPUT: {:?}\n", res);
+        assert_eq!(
+            res,
+            vec![
+                Link {
+                    start_index: 22,
+                    end_index: 46,
+                    link: LinkType::IncludeRangeTo(PathBuf::from("file.rs"), ..20),
+                    link_text: "{{#include file.rs::20}}",
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn test_find_links_with_full_range() {
+        let s = "Some random text with {{#include file.rs::}}...";
+        let res = find_links(s).collect::<Vec<_>>();
+        println!("\nOUTPUT: {:?}\n", res);
+        assert_eq!(
+            res,
+            vec![
+                Link {
+                    start_index: 22,
+                    end_index: 44,
+                    link: LinkType::IncludeRangeFull(PathBuf::from("file.rs"), ..),
+                    link_text: "{{#include file.rs::}}",
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn test_find_links_with_no_range_specified() {
+        let s = "Some random text with {{#include file.rs}}...";
+        let res = find_links(s).collect::<Vec<_>>();
+        println!("\nOUTPUT: {:?}\n", res);
+        assert_eq!(
+            res,
+            vec![
+                Link {
+                    start_index: 22,
+                    end_index: 42,
+                    link: LinkType::IncludeRangeFull(PathBuf::from("file.rs"), ..),
+                    link_text: "{{#include file.rs}}",
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn test_find_links_escaped_link() {
+        let s = "Some random text with escaped playpen \\{{#playpen file.rs editable}} ...";
+
+        let res = find_links(s).collect::<Vec<_>>();
+        println!("\nOUTPUT: {:?}\n", res);
+
+        assert_eq!(
+            res,
+            vec![
+                Link {
+                    start_index: 38,
+                    end_index: 68,
+                    link: LinkType::Escaped,
+                    link_text: "\\{{#playpen file.rs editable}}",
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn test_find_playpens_with_properties() {
+        let s = "Some random text with escaped playpen {{#playpen file.rs editable }} and some \
+                 more\n text {{#playpen my.rs editable no_run should_panic}} ...";
+
+        let res = find_links(s).collect::<Vec<_>>();
+        println!("\nOUTPUT: {:?}\n", res);
+        assert_eq!(
+            res,
+            vec![
+                Link {
+                    start_index: 38,
+                    end_index: 68,
+                    link: LinkType::Playpen(PathBuf::from("file.rs"), vec!["editable"]),
+                    link_text: "{{#playpen file.rs editable }}",
+                },
+                Link {
+                    start_index: 89,
+                    end_index: 136,
+                    link: LinkType::Playpen(
+                        PathBuf::from("my.rs"),
+                        vec!["editable", "no_run", "should_panic"],
+                    ),
+                    link_text: "{{#playpen my.rs editable no_run should_panic}}",
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn test_find_all_link_types() {
+        let s = "Some random text with escaped playpen {{#include file.rs}} and \\{{#contents are \
+                 insignifficant in escaped link}} some more\n text  {{#playpen my.rs editable \
+                 no_run should_panic}} ...";
+
+        let res = find_links(s).collect::<Vec<_>>();
+        println!("\nOUTPUT: {:?}\n", res);
+        assert_eq!(res.len(), 3);
+        assert_eq!(
+            res[0],
             Link {
-                start_index: 22,
-                end_index: 48,
-                link: LinkType::IncludeRange(PathBuf::from("file.rs"), 10..20),
-                link_text: "{{#include file.rs:10:20}}",
-            },
-        ]
-    );
-}
-
-#[test]
-fn test_find_links_with_from_range() {
-    let s = "Some random text with {{#include file.rs:10:}}...";
-    let res = find_links(s).collect::<Vec<_>>();
-    println!("\nOUTPUT: {:?}\n", res);
-    assert_eq!(
-        res,
-        vec![
-            Link {
-                start_index: 22,
-                end_index: 46,
-                link: LinkType::IncludeRangeFrom(PathBuf::from("file.rs"), 10..),
-                link_text: "{{#include file.rs:10:}}",
-            },
-        ]
-    );
-}
-
-#[test]
-fn test_find_links_with_to_range() {
-    let s = "Some random text with {{#include file.rs::20}}...";
-    let res = find_links(s).collect::<Vec<_>>();
-    println!("\nOUTPUT: {:?}\n", res);
-    assert_eq!(
-        res,
-        vec![
-            Link {
-                start_index: 22,
-                end_index: 46,
-                link: LinkType::IncludeRangeTo(PathBuf::from("file.rs"), ..20),
-                link_text: "{{#include file.rs::20}}",
-            },
-        ]
-    );
-}
-
-#[test]
-fn test_find_links_with_full_range() {
-    let s = "Some random text with {{#include file.rs::}}...";
-    let res = find_links(s).collect::<Vec<_>>();
-    println!("\nOUTPUT: {:?}\n", res);
-    assert_eq!(
-        res,
-        vec![
-            Link {
-                start_index: 22,
-                end_index: 44,
+                start_index: 38,
+                end_index: 58,
                 link: LinkType::IncludeRangeFull(PathBuf::from("file.rs"), ..),
-                link_text: "{{#include file.rs::}}",
-            },
-        ]
-    );
-}
+                link_text: "{{#include file.rs}}",
+            }
+        );
+        assert_eq!(
+            res[1],
+            Link {
+                start_index: 63,
+                end_index: 112,
+                link: LinkType::Escaped,
+                link_text: "\\{{#contents are insignifficant in escaped link}}",
+            }
+        );
+        assert_eq!(
+            res[2],
+            Link {
+                start_index: 130,
+                end_index: 177,
+                link: LinkType::Playpen(
+                    PathBuf::from("my.rs"),
+                    vec!["editable", "no_run", "should_panic"]
+                ),
+                link_text: "{{#playpen my.rs editable no_run should_panic}}",
+            }
+        );
+    }
 
-#[test]
-fn test_find_links_escaped_link() {
-    let s = "Some random text with escaped playpen \\{{#playpen file.rs editable}} ...";
-
-    let res = find_links(s).collect::<Vec<_>>();
-    println!("\nOUTPUT: {:?}\n", res);
-
-    assert_eq!(res,
-               vec![Link {
-                        start_index: 38,
-                        end_index: 68,
-                        link: LinkType::Escaped,
-                        link_text: "\\{{#playpen file.rs editable}}",
-                    }]);
-}
-
-#[test]
-fn test_find_playpens_with_properties() {
-    let s = "Some random text with escaped playpen {{#playpen file.rs editable }} and some more\n \
-             text {{#playpen my.rs editable no_run should_panic}} ...";
-
-    let res = find_links(s).collect::<Vec<_>>();
-    println!("\nOUTPUT: {:?}\n", res);
-    assert_eq!(res,
-               vec![Link {
-                        start_index: 38,
-                        end_index: 68,
-                        link: LinkType::Playpen(PathBuf::from("file.rs"), vec!["editable"]),
-                        link_text: "{{#playpen file.rs editable }}",
-                    },
-                    Link {
-                        start_index: 89,
-                        end_index: 136,
-                        link: LinkType::Playpen(PathBuf::from("my.rs"),
-                                                vec!["editable", "no_run", "should_panic"]),
-                        link_text: "{{#playpen my.rs editable no_run should_panic}}",
-                    }]);
-}
-
-#[test]
-fn test_find_all_link_types() {
-    let s = "Some random text with escaped playpen {{#include file.rs}} and \\{{#contents are \
-             insignifficant in escaped link}} some more\n text  {{#playpen my.rs editable no_run \
-             should_panic}} ...";
-
-    let res = find_links(s).collect::<Vec<_>>();
-    println!("\nOUTPUT: {:?}\n", res);
-    assert_eq!(res.len(), 3);
-    assert_eq!(res[0],
-               Link {
-                   start_index: 38,
-                   end_index: 58,
-                   link: LinkType::IncludeRangeFull(PathBuf::from("file.rs"), ..),
-                   link_text: "{{#include file.rs}}",
-               });
-    assert_eq!(res[1],
-               Link {
-                   start_index: 63,
-                   end_index: 112,
-                   link: LinkType::Escaped,
-                   link_text: "\\{{#contents are insignifficant in escaped link}}",
-               });
-    assert_eq!(res[2],
-               Link {
-                   start_index: 130,
-                   end_index: 177,
-                   link: LinkType::Playpen(PathBuf::from("my.rs"),
-                                           vec!["editable", "no_run", "should_panic"]),
-                   link_text: "{{#playpen my.rs editable no_run should_panic}}",
-               });
 }

--- a/src/preprocess/links.rs
+++ b/src/preprocess/links.rs
@@ -28,7 +28,6 @@ impl Preprocessor for LinkPreprocessor {
 
         book.for_each_mut(|section: &mut BookItem| {
             if let BookItem::Chapter(ref mut ch) = *section {
-                println!("Checking {}", ch);
                 let base = ch.path
                     .parent()
                     .map(|dir| src_dir.join(dir))
@@ -52,12 +51,12 @@ fn replace_all<P: AsRef<Path>>(s: &str, path: P) -> String {
     let mut replaced = String::new();
 
     for playpen in find_links(s) {
-        println!("{} {:?}", path.display(), playpen);
         replaced.push_str(&s[previous_end_index..playpen.start_index]);
 
         match playpen.render_with_path(&path) {
             Ok(new_content) => {
                 replaced.push_str(&new_content);
+                previous_end_index = playpen.end_index;
             }
             Err(e) => {
                 error!("Error updating \"{}\", {}", playpen.link_text, e);

--- a/tests/dummy_book/mod.rs
+++ b/tests/dummy_book/mod.rs
@@ -85,6 +85,18 @@ pub fn assert_contains_strings<P: AsRef<Path>>(filename: P, strings: &[&str]) {
     }
 }
 
+pub fn assert_doesnt_contain_strings<P: AsRef<Path>>(filename: P, strings: &[&str]) {
+    let filename = filename.as_ref();
+    let content = file_to_string(filename).expect("Couldn't read the file's contents");
+
+    for s in strings {
+        assert!(!content.contains(s),
+                "Found {:?} in {}\n\n{}",
+                s,
+                filename.display(),
+                content);
+    }
+}
 
 
 /// Recursively copy an entire directory tree to somewhere else (a la `cp -r`).

--- a/tests/dummy_book/src/SUMMARY.md
+++ b/tests/dummy_book/src/SUMMARY.md
@@ -2,10 +2,11 @@
 
 [Introduction](intro.md)
 
-- [First Chapter](./first/index.md)
-    - [Nested Chapter](./first/nested.md)
-- [Second Chapter](./second.md)
+- [First Chapter](first/index.md)
+    - [Nested Chapter](first/nested.md)
+    - [Includes](first/includes.md)
+- [Second Chapter](second.md)
 
 ---
 
-[Conclusion](./conclusion.md)
+[Conclusion](conclusion.md)

--- a/tests/dummy_book/src/first/includes.md
+++ b/tests/dummy_book/src/first/includes.md
@@ -1,0 +1,3 @@
+# Includes
+
+{{#include ../SUMMARY.md::}}

--- a/tests/rendered_output.rs
+++ b/tests/rendered_output.rs
@@ -29,7 +29,7 @@ const TOC_TOP_LEVEL: &[&'static str] = &[
     "Conclusion",
     "Introduction",
 ];
-const TOC_SECOND_LEVEL: &[&'static str] = &["1.1. Nested Chapter"];
+const TOC_SECOND_LEVEL: &[&'static str] = &["1.1. Nested Chapter", "1.2. Includes"];
 
 /// Make sure you can load the dummy book and build it without panicking.
 #[test]
@@ -49,7 +49,8 @@ fn by_default_mdbook_generates_rendered_content_in_the_book_directory() {
     md.build().unwrap();
 
     assert!(temp.path().join("book").exists());
-    assert!(temp.path().join("book").join("index.html").exists());
+    let index_file = md.build_dir_for("html").join("index.html");
+    assert!(index_file.exists());
 }
 
 #[test]
@@ -281,7 +282,7 @@ fn create_missing_file_with_config() {
 /// This makes sure you can include a Rust file with `{{#playpen example.rs}}`.
 /// Specification is in `book-example/src/format/rust.md`
 #[test]
-fn able_to_include_rust_files_in_chapters() {
+fn able_to_include_playpen_files_in_chapters() {
     let temp = DummyBook::new().build().unwrap();
     let md = MDBook::load(temp.path()).unwrap();
     md.build().unwrap();
@@ -293,6 +294,19 @@ fn able_to_include_rust_files_in_chapters() {
         r#"println!(&quot;Hello World!&quot;);"#,
     ];
     assert_contains_strings(second, playpen_strings);
+}
+
+/// This makes sure you can include a Rust file with `{{#include ../SUMMARY.md}}`.
+#[test]
+fn able_to_include_files_in_chapters() {
+    let temp = DummyBook::new().build().unwrap();
+    let md = MDBook::load(temp.path()).unwrap();
+    md.build().unwrap();
+
+    let includes = temp.path().join("book/first/includes.html");
+
+    let summary_strings = &["<h1>Summary</h1>", ">First Chapter</a>"];
+    assert_contains_strings(includes, summary_strings);
 }
 
 #[test]

--- a/tests/rendered_output.rs
+++ b/tests/rendered_output.rs
@@ -7,7 +7,7 @@ extern crate walkdir;
 
 mod dummy_book;
 
-use dummy_book::{assert_contains_strings, DummyBook};
+use dummy_book::{assert_contains_strings, assert_doesnt_contain_strings, DummyBook};
 
 use std::fs;
 use std::io::Write;
@@ -293,7 +293,9 @@ fn able_to_include_playpen_files_in_chapters() {
         r#"class="playpen""#,
         r#"println!(&quot;Hello World!&quot;);"#,
     ];
-    assert_contains_strings(second, playpen_strings);
+
+    assert_contains_strings(&second, playpen_strings);
+    assert_doesnt_contain_strings(&second, &["{{#playpen example.rs}}"]);
 }
 
 /// This makes sure you can include a Rust file with `{{#include ../SUMMARY.md}}`.
@@ -306,7 +308,9 @@ fn able_to_include_files_in_chapters() {
     let includes = temp.path().join("book/first/includes.html");
 
     let summary_strings = &["<h1>Summary</h1>", ">First Chapter</a>"];
-    assert_contains_strings(includes, summary_strings);
+    assert_contains_strings(&includes, summary_strings);
+
+    assert_doesnt_contain_strings(&includes, &["{{#include ../SUMMARY.md::}}"]);
 }
 
 #[test]


### PR DESCRIPTION
Fixes an issue raised in #558.

> Including a Rust file seems broken - https://rust-lang-nursery.github.io/mdBook/format/rust.html. Looks like it was introduced by #532.

Turns out we forgot to recursively apply replace_all() in #532, instead we just iterated over the chapters in the top level without doing any recursion. 

As well as fixing the bug mentioned, I've also made the `sections` field private so we don't accidentally get these sorts of bugs again.