### PR TITLE
fix(doc): make installation from git work again

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ j
    the git version of mdBook yourself. Cargo makes this ***super easy***!
 
    ```
-   cargo install --git https://github.com/rust-lang-nursery/mdBook.git
+   cargo install --git https://github.com/rust-lang-nursery/mdBook.git mdbook
    ```
 
    Again, make sure to add the Cargo bin directory to your `PATH`.


### PR DESCRIPTION
cargo install --git https://github.com/rust-lang-nursery/mdBook.git
leads to error: multiple packages with binaries found: mdbook, mdbook-wordcount
Fix: append name of binary (`mdbook`).