### PR TITLE
fix(theme/index): Use localStorage, not store

### DIFF
--- a/src/theme/index.hbs
+++ b/src/theme/index.hbs
@@ -46,7 +46,7 @@
         <!-- Set the theme before any content is loaded, prevents flash -->
         <script type="text/javascript">
             var theme;
-            try { theme = store.get('mdbook-theme'); } catch(e) { } 
+            try { theme = localStorage.getItem('mdbook-theme'); } catch(e) { } 
             if (theme === null || theme === undefined) { theme = 'light'; }
             document.body.className = theme;
         </script>
@@ -55,7 +55,7 @@
         <script type="text/javascript">
             var sidebar = 'hidden';
             if (document.body.clientWidth >= 1080) {
-                try { sidebar = store.get('mdbook-sidebar'); } catch(e) { }
+                try { sidebar = localStorage.getItem('mdbook-sidebar'); } catch(e) { }
                 sidebar = sidebar || 'visible';
             }
             document.querySelector('html').classList.add("sidebar-" + sidebar);

--- a/src/theme/index.hbs
+++ b/src/theme/index.hbs
@@ -43,6 +43,22 @@
 
     </head>
     <body class="light">
+        <!-- Work around some values being stored in localStorage wrapped in quotes -->
+        <script type="text/javascript">
+            try {
+                var theme = localStorage.getItem('mdbook-theme');
+                var sidebar = localStorage.getItem('mdbook-sidebar');
+
+                if (theme.startsWith('"') && theme.endsWith('"')) {
+                    localStorage.setItem('mdbook-theme', theme.slice(1, theme.length - 1));
+                }
+
+                if (sidebar.startsWith('"') && sidebar.endsWith('"')) {
+                    localStorage.setItem('mdbook-sidebar', sidebar.slice(1, sidebar.length - 1));
+                }
+            } catch (e) { }
+        </script>
+
         <!-- Set the theme before any content is loaded, prevents flash -->
         <script type="text/javascript">
             var theme;


### PR DESCRIPTION
~This still doesn't explain #573.~ Added a commit to fix it.

We could solve this in a few ways:
 - maintain the convention (in 4/5 places) that values are stored in `localStorage` wrapped in quotes
 - introduce theme validation in two separate places (`index.html` and `book.js`)
 - unwrap items in `localStorage` in one place

For this PR I went with the last option.