### PR TITLE
fix(theme/book): Use passive listeners for touchstart, touchmove

### DIFF
--- a/src/theme/book.js
+++ b/src/theme/book.js
@@ -422,7 +422,7 @@ function playpen_text(playpen) {
             x: e.touches[0].clientX,
             time: Date.now()
         };
-    });
+    }, { passive: true });
 
     document.addEventListener('touchmove', function (e) {
         if (!firstContact)
@@ -440,7 +440,7 @@ function playpen_text(playpen) {
 
             firstContact = null;
         }
-    });
+    }, { passive: true });
 
     // Scroll sidebar to current active section
     var activeSection = sidebar.querySelector(".active");


### PR DESCRIPTION
["Passive event listeners are a new feature in the DOM spec that enable developers to opt-in to better scroll performance by eliminating the need for scrolling to block on touch and wheel event listeners."](https://github.com/WICG/EventListenerOptions/blob/gh-pages/explainer.md)