### PR TITLE
Missing backends shouldn't be fatal

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mdbook"
-version = "0.1.0"
+version = "0.1.1-alpha.0"
 authors = ["Mathieu David <mathieudavid@mathieudavid.org>", "Michael-F-Bryan <michaelfbryan@gmail.com>"]
 description = "create books from markdown files (like Gitbook)"
 documentation = "http://rust-lang-nursery.github.io/mdBook/index.html"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mdbook"
-version = "0.0.29-alpha.0"
+version = "0.1.0"
 authors = ["Mathieu David <mathieudavid@mathieudavid.org>", "Michael-F-Bryan <michaelfbryan@gmail.com>"]
 description = "create books from markdown files (like Gitbook)"
 documentation = "http://rust-lang-nursery.github.io/mdBook/index.html"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "mdbook"
 version = "0.0.29-alpha.0"
-authors = ["Mathieu David <mathieudavid@mathieudavid.org>"]
+authors = ["Mathieu David <mathieudavid@mathieudavid.org>", "Michael-F-Bryan <michaelfbryan@gmail.com>"]
 description = "create books from markdown files (like Gitbook)"
 documentation = "http://rust-lang-nursery.github.io/mdBook/index.html"
 repository = "https://github.com/rust-lang-nursery/mdBook"

--- a/book-example/src/for_developers/preprocessors.md
+++ b/book-example/src/for_developers/preprocessors.md
@@ -4,7 +4,7 @@ A *preprocessor* is simply a bit of code which gets run immediately after the
 book is loaded and before it gets rendered, allowing you to update and mutate
 the book. Possible use cases are:
 
-- Creating custom helpers like `{{#include /path/to/file.md}}`
+- Creating custom helpers like `\{{#include /path/to/file.md}}`
 - Updating links so `[some chapter](some_chapter.md)` is automatically changed 
   to `[some chapter](some_chapter.html)` for the HTML renderer
 - Substituting in latex-style expressions (`$$ \frac{1}{3} $$`) with their 

--- a/tests/alternate_backends.rs
+++ b/tests/alternate_backends.rs
@@ -25,6 +25,13 @@ fn failing_alternate_backend() {
 }
 
 #[test]
+fn missing_backends_arent_fatal() {
+    let (md, _temp) = dummy_book_with_backend("missing", "trduyvbhijnorgevfuhn");
+
+    assert!(md.build().is_ok());
+}
+
+#[test]
 fn alternate_backend_with_arguments() {
     let (md, _temp) = dummy_book_with_backend("arguments", "echo Hello World!");
 


### PR DESCRIPTION
At the moment if a backend is missing (i.e. it fails to start), we blow up and stop the entire rendering process. This is a problem when people add a particular renderer to their `book.toml` but then someone else trying to build the book doesn't have that backend installed.

Instead of throwing an error and exiting we now emit a warning and continue on to the next renderer.