### PR TITLE
Expose functionality for creating core types

### DIFF
--- a/src/book/book.rs
+++ b/src/book/book.rs
@@ -101,6 +101,12 @@ impl Book {
     {
         for_each_mut(&mut func, &mut self.sections);
     }
+
+    /// Append a `BookItem` to the `Book`.
+    pub fn push_item<I: Into<BookItem>>(&mut self, item: I) -> &mut Self {
+        self.sections.push(item.into());
+        self
+    }
 }
 
 pub fn for_each_mut<'a, F, I>(func: &mut F, items: I)
@@ -124,6 +130,12 @@ pub enum BookItem {
     Chapter(Chapter),
     /// A section separator.
     Separator,
+}
+
+impl From<Chapter> for BookItem {
+    fn from(other: Chapter) -> BookItem {
+        BookItem::Chapter(other)
+    }
 }
 
 /// The representation of a "chapter", usually mapping to a single file on

--- a/src/renderer/mod.rs
+++ b/src/renderer/mod.rs
@@ -26,6 +26,8 @@ use errors::*;
 use config::Config;
 use book::Book;
 
+const MDBOOK_VERSION: &str = env!("CARGO_PKG_VERSION");
+
 /// An arbitrary `mdbook` backend.
 ///
 /// Although it's quite possible for you to import `mdbook` as a library and
@@ -68,7 +70,7 @@ pub struct RenderContext {
 
 impl RenderContext {
     /// Create a new `RenderContext`.
-    pub(crate) fn new<P, Q>(root: P, book: Book, config: Config, destination: Q) -> RenderContext
+    pub fn new<P, Q>(root: P, book: Book, config: Config, destination: Q) -> RenderContext
     where
         P: Into<PathBuf>,
         Q: Into<PathBuf>,
@@ -76,7 +78,7 @@ impl RenderContext {
         RenderContext {
             book: book,
             config: config,
-            version: env!("CARGO_PKG_VERSION").to_string(),
+            version: MDBOOK_VERSION.to_string(),
             root: root.into(),
             destination: destination.into(),
         }


### PR DESCRIPTION
Alternate backends need to be able to create a `RenderContext` (e.g. for a "standalone" mode or testing) and add chapters to a `Book`.