### PR TITLE
Updated Cargo.toml metadata to make releases easier

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,11 @@ exclude = [
     "src/theme/stylus/**",
 ]
 
+[package.metadata.release]
+sign-commit = true
+push-remote = "upstream"
+tag-prefix = "v"
+
 [dependencies]
 clap = "2.24"
 chrono = "0.4"
@@ -65,6 +70,3 @@ serve = ["iron", "staticfile", "ws"]
 doc = false
 name = "mdbook"
 path = "src/bin/mdbook.rs"
-
-[workspace]
-members = ["book-example/src/for_developers/mdbook-wordcount"]

--- a/book-example/src/for_developers/mdbook-wordcount/Cargo.toml
+++ b/book-example/src/for_developers/mdbook-wordcount/Cargo.toml
@@ -2,9 +2,8 @@
 name = "mdbook-wordcount"
 version = "0.1.0"
 authors = ["Michael Bryan <michaelfbryan@gmail.com>"]
-workspace = "../../../.."
 
 [dependencies]
-mdbook = { path = "../../../.." }
+mdbook = { path = "../../../..", version = "*" }
 serde = "1.0"
 serde_derive = "1.0"


### PR DESCRIPTION
When doing the `0.1.0` release a couple days back i forgot to tell `cargo-release` to prepend the tag with `v` (i.e. `v0.1.0`) and as a result CI didn't know it was meant to build binaries and push them to github releases. This just updates a couple fields in `Cargo.toml` so we don't have that issue again.

I've also removed `mdbook-wordcount` from the workspace so hopefully it should stop getting error messages like this when `mdbook-wordcount` isn't updated in lockstep with `mdbook`.

```
no matching package named `mdbook` found (required by `mdbook-wordcount`)
  location searched: file:///home/michael/Documents/forks/mdBook
  version required: = 0.1.0
```