### PR TITLE
Translate relative links to other .md files during rendering (fixes #588)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,8 @@ tempdir = "0.3.4"
 itertools = "0.7"
 shlex = "0.1"
 toml-query = "0.6"
+relative-path = { version = "0.3", features = ["serde"] }
+url = "1.6"
 
 # Watch feature
 notify = { version = "4.0", optional = true }

--- a/book-example/src/SUMMARY.md
+++ b/book-example/src/SUMMARY.md
@@ -19,5 +19,6 @@
 - [For Developers](for_developers/index.md)
     - [Preprocessors](for_developers/preprocessors.md)
     - [Alternate Backends](for_developers/backends.md)
+- [Test](test.md)
 -----------
 [Contributors](misc/contributors.md)

--- a/book-example/src/cli/init.md
+++ b/book-example/src/cli/init.md
@@ -22,7 +22,7 @@ configuration files, etc.
 - The `book` directory is where your book is rendered. All the output is ready to be uploaded
 to a server to be seen by your audience.
 
-- The `SUMMARY.md` file is the most important file, it's the skeleton of your book and is discussed in more detail in another  [chapter](format/summary.html).
+- The `SUMMARY.md` file is the most important file, it's the skeleton of your book and is discussed in more detail in another  [chapter](../format/summary.md).
 
 #### Tip & Trick: Hidden Feature
 When a `SUMMARY.md` file already exists, the `init` command will first parse it and generate the missing files according to the paths used in the `SUMMARY.md`. This allows you to think and create the whole structure of your book and then let mdBook generate it for you.

--- a/book-example/src/for_developers/index.md
+++ b/book-example/src/for_developers/index.md
@@ -11,8 +11,8 @@ The *For Developers* chapters are here to show you the more advanced usage of
 
 The two main ways a developer can hook into the book's build process is via,
 
-- [Preprocessors](for_developers/preprocessors.html)
-- [Alternate Backends](for_developers/backends.html)
+- [Preprocessors](preprocessors.md)
+- [Alternate Backends](backends.md)
 
 
 ## The Build Process

--- a/book-example/src/test.md
+++ b/book-example/src/test.md
@@ -1,0 +1,5 @@
+# This is just a test page
+
+* [Link to format summary](format/summary.md)
+* [Link to directory (doesn't behave well)](format)
+* [Bad Link :(](format/bad.md)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -95,6 +95,8 @@ extern crate shlex;
 extern crate tempdir;
 extern crate toml;
 extern crate toml_query;
+extern crate relative_path;
+extern crate url;
 
 #[cfg(test)]
 #[macro_use]
@@ -115,6 +117,7 @@ pub use config::Config;
 /// The error types used through out this crate.
 pub mod errors {
     use std::path::PathBuf;
+    use relative_path::FromPathError;
 
     error_chain!{
         foreign_links {
@@ -122,6 +125,7 @@ pub mod errors {
             HandlebarsRender(::handlebars::RenderError) #[doc = "Handlebars rendering failed"];
             HandlebarsTemplate(Box<::handlebars::TemplateError>) #[doc = "Unable to parse the template"];
             Utf8(::std::string::FromUtf8Error) #[doc = "Invalid UTF-8"];
+            FromPathError(FromPathError) #[doc = "Failed to convert to relative path"];
         }
 
         links {

--- a/src/utils/link_filter.rs
+++ b/src/utils/link_filter.rs
@@ -1,0 +1,61 @@
+use url::Url;
+use relative_path::RelativePath;
+
+/// Translate the given destination from a relative link with an '.md' extension, to a link with
+/// a '.html' extension.
+pub struct ChangeExtLinkFilter<'a, F> {
+    base: &'a RelativePath,
+    is_dest: F,
+    expected: &'a str,
+    ext: &'a str,
+}
+
+impl<'a, F> ChangeExtLinkFilter<'a, F>
+    where F: Fn(&RelativePath) -> bool
+{
+    pub fn new(base: &'a RelativePath, is_dest: F, expected: &'a str, ext: &'a str) -> ChangeExtLinkFilter<'a, F> {
+        ChangeExtLinkFilter {
+            base: base,
+            is_dest: is_dest,
+            expected: expected,
+            ext: ext,
+        }
+    }
+}
+
+impl<'a, F> LinkFilter for ChangeExtLinkFilter<'a, F>
+    where F: Fn(&RelativePath) -> bool
+{
+    fn apply(&self, dest: &str) -> Option<String> {
+        use url::ParseError;
+
+        // Verify that specified URL is relative.
+        if let Err(ParseError::RelativeUrlWithoutBase) = Url::parse(dest) {
+            // extract fragment.
+            let mut split = dest.splitn(2, '#');
+
+            if let Some(base) = split.next() {
+                let dest = RelativePath::new(base);
+
+                if Some(self.expected) == dest.extension() && (self.is_dest)(dest) {
+                    let dest = self.base.join_normalized(dest).with_extension(self.ext);
+                    let dest = dest.display().to_string();
+
+                    if let Some(fragment) = split.next() {
+                        return Some(format!("{}#{}", dest, fragment));
+                    }
+
+                    return Some(dest);
+                }
+            }
+        }
+
+        None
+    }
+}
+
+/// A filter to optionally apply to links.
+pub trait LinkFilter {
+    /// Optionally translate the given destination, if applicable.
+    fn apply(&self, dest: &str) -> Option<String>;
+}


### PR DESCRIPTION
I'm trying to avoid as many is_file checks as possible by analysing the destination when possible.

Adds two dependencies:
* `url`, to conveniently parse URLs to determine if they are relative or not.
* `relative-path` (A crate of mine), parses _only_ forward slash paths and permits convenient decomposition into components that can be translated.
   This also makes sure that there are no platform-dependent path manipulations.

I can try to avoid using `relative-path` if wanted, but `url` is a bit harder.