### PR TITLE
Updated the light theme to have a lighter scrollbar

### DIFF
--- a/src/theme/book.css
+++ b/src/theme/book.css
@@ -344,7 +344,7 @@ html:not(.sidebar-visible) #menu-bar:not(:hover).folded > #menu-bar-sticky-conta
   background: #fafafa;
 }
 .light .sidebar::-webkit-scrollbar-thumb {
-  background: #364149;
+  background: #ccc;
 }
 .light .chapter li {
   color: #aaa;
@@ -474,7 +474,7 @@ html:not(.sidebar-visible) #menu-bar:not(:hover).folded > #menu-bar-sticky-conta
   background: #fff;
 }
 .light ::-webkit-scrollbar-thumb {
-  background: #333;
+  background: #ccc;
 }
 .coal {
   color: #98a3ad;
@@ -640,7 +640,7 @@ html:not(.sidebar-visible) #menu-bar:not(:hover).folded > #menu-bar-sticky-conta
   background: #141617;
 }
 .coal ::-webkit-scrollbar-thumb {
-  background: #98a3ad;
+  background: #a1adb8;
 }
 .navy {
   color: #bcbdd0;
@@ -806,7 +806,7 @@ html:not(.sidebar-visible) #menu-bar:not(:hover).folded > #menu-bar-sticky-conta
   background: #161923;
 }
 .navy ::-webkit-scrollbar-thumb {
-  background: #bcbdd0;
+  background: #c8c9db;
 }
 .rust {
   color: #262625;
@@ -972,7 +972,7 @@ html:not(.sidebar-visible) #menu-bar:not(:hover).folded > #menu-bar-sticky-conta
   background: #e1e1db;
 }
 .rust ::-webkit-scrollbar-thumb {
-  background: #262625;
+  background: #c8c9db;
 }
 .ayu {
   color: #c5c5c5;
@@ -1138,7 +1138,7 @@ html:not(.sidebar-visible) #menu-bar:not(:hover).folded > #menu-bar-sticky-conta
   background: #0f1419;
 }
 .ayu ::-webkit-scrollbar-thumb {
-  background: #c5c5c5;
+  background: #c8c9db;
 }
 @media only print {
   #sidebar,

--- a/src/theme/stylus/themes/ayu.styl
+++ b/src/theme/stylus/themes/ayu.styl
@@ -9,6 +9,8 @@ $sidebar-non-existant = #5c6773
 $sidebar-active = #ffb454
 $sidebar-spacer = #2d334f
 
+$scrollbar = $sidebar-fg
+
 $icons = #737480
 $icons-hover = #b7b9cc
 

--- a/src/theme/stylus/themes/base.styl
+++ b/src/theme/stylus/themes/base.styl
@@ -38,7 +38,7 @@
         }
 
         &::-webkit-scrollbar-thumb {
-            background: $sidebar-fg;
+            background: $scrollbar;
         }
     }
 
@@ -186,6 +186,6 @@
     }
 
     ::-webkit-scrollbar-thumb {
-        background: $fg;
+        background: $scrollbar;
     }
 }

--- a/src/theme/stylus/themes/coal.styl
+++ b/src/theme/stylus/themes/coal.styl
@@ -9,6 +9,8 @@ $sidebar-non-existant = #505254
 $sidebar-active = #3473ad
 $sidebar-spacer = #393939
 
+$scrollbar = $sidebar-fg
+
 $icons = #43484d
 $icons-hover = #b3c0cc
 

--- a/src/theme/stylus/themes/light.styl
+++ b/src/theme/stylus/themes/light.styl
@@ -9,6 +9,8 @@ $sidebar-non-existant = #aaaaaa
 $sidebar-active = #008cff
 $sidebar-spacer = #f4f4f4
 
+$scrollbar = #cccccc
+
 $icons = #cccccc
 $icons-hover = #333333
 

--- a/src/theme/stylus/themes/navy.styl
+++ b/src/theme/stylus/themes/navy.styl
@@ -9,6 +9,8 @@ $sidebar-non-existant = #505274
 $sidebar-active = #2b79a2
 $sidebar-spacer = #2d334f
 
+$scrollbar = $sidebar-fg
+
 $icons = #737480
 $icons-hover = #b7b9cc
 

--- a/src/theme/stylus/themes/rust.styl
+++ b/src/theme/stylus/themes/rust.styl
@@ -9,6 +9,8 @@ $sidebar-non-existant = #505254
 $sidebar-active = #e69f67
 $sidebar-spacer = #45373a
 
+$scrollbar = $sidebar-fg
+
 $icons = #737480
 $icons-hover = #262625
 


### PR DESCRIPTION
The current scrollbar colour for the light theme is a little jarring and doesn't quite feel like it fits the rest of the theme. This just pulls the scrollbar colour out into its own variable which defaults to the `$sidebar-fg`, overriding it to `#ccc` for the light theme.

---

Before:

![screenshot_2018-01-26_125739](https://user-images.githubusercontent.com/17380079/35467975-1ae73792-0351-11e8-847b-d9fbfdd41533.png)


After:

![screenshot_2018-01-27_105044](https://user-images.githubusercontent.com/17380079/35467972-116404c0-0351-11e8-8a24-54841c4a25ac.png)
