### PR TITLE
WIP: Add support for virtual chapters

### DIFF
--- a/book-example/src/SUMMARY.md
+++ b/book-example/src/SUMMARY.md
@@ -10,6 +10,7 @@
     - [clean](cli/clean.md)
 - [Format](format/format.md)
     - [SUMMARY.md](format/summary.md)
+        - [Virtual Chapter]()
     - [Configuration](format/config.md)
     - [Theme](format/theme/theme.md)
         - [index.hbs](format/theme/index-hbs.md)

--- a/src/bin/init.rs
+++ b/src/bin/init.rs
@@ -4,7 +4,6 @@ use std::process::Command;
 use clap::{App, ArgMatches, SubCommand};
 use mdbook::MDBook;
 use mdbook::errors::Result;
-use mdbook::utils;
 use mdbook::config;
 use get_book_dir;
 

--- a/src/book/book.rs
+++ b/src/book/book.rs
@@ -133,6 +133,9 @@ pub enum BookItem {
     VirtualChapter(VirtualChapter),
     /// A section separator.
     Separator,
+    // To make sure clients have a `_ =>` case
+    #[doc(hidden)]
+    __NonExhaustive,
 }
 
 impl From<Chapter> for BookItem {

--- a/src/book/book.rs
+++ b/src/book/book.rs
@@ -136,13 +136,13 @@ pub enum BookItem {
 }
 
 impl From<Chapter> for BookItem {
-    fn from(other: Chapter) -> BookItem {
+    fn from(other: Chapter) -> Self {
         BookItem::Chapter(other)
     }
 }
 
 impl From<VirtualChapter> for BookItem {
-    fn from(other: VirtualChapter) -> BookItem {
+    fn from(other: VirtualChapter) -> Self {
         BookItem::VirtualChapter(other)
     }
 }
@@ -199,8 +199,8 @@ pub struct VirtualChapter {
 
 impl VirtualChapter {
     /// Create a new chapter with the provided content.
-    pub fn new(name: &str, content: String) -> VirtualChapter {
-        VirtualChapter {
+    pub fn new(name: &str, content: String) -> Self {
+        Self {
             name: name.to_string(),
             content: content,
             ..Default::default()
@@ -246,6 +246,7 @@ fn load_summary_item<P: AsRef<Path>>(
             load_chapter(link, src_dir, parent_names).map(|c| BookItem::Chapter(c))
         }
         SummaryItem::VirtualLink(ref link) => unimplemented!(),
+        SummaryItem::Separator => Ok(BookItem::Separator),
     }
 }
 

--- a/src/book/book.rs
+++ b/src/book/book.rs
@@ -245,6 +245,7 @@ fn load_summary_item<P: AsRef<Path>>(
         SummaryItem::Link(ref link) => {
             load_chapter(link, src_dir, parent_names).map(|c| BookItem::Chapter(c))
         }
+        SummaryItem::VirtualLink(ref link) => unimplemented!(),
     }
 }
 

--- a/src/book/book.rs
+++ b/src/book/book.rs
@@ -129,6 +129,8 @@ where
 pub enum BookItem {
     /// A nested chapter.
     Chapter(Chapter),
+    /// A nested virtual chapter.
+    VirtualChapter(VirtualChapter),
     /// A section separator.
     Separator,
 }
@@ -136,6 +138,12 @@ pub enum BookItem {
 impl From<Chapter> for BookItem {
     fn from(other: Chapter) -> BookItem {
         BookItem::Chapter(other)
+    }
+}
+
+impl From<VirtualChapter> for BookItem {
+    fn from(other: VirtualChapter) -> BookItem {
+        BookItem::VirtualChapter(other)
     }
 }
 
@@ -170,6 +178,31 @@ impl Chapter {
             content: content,
             path: path.into(),
             parent_names: parent_names,
+            ..Default::default()
+        }
+    }
+}
+
+/// The representation of a "virtual chapter", available for namespacing
+/// purposes and not mapping to a file on disk.
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+pub struct VirtualChapter {
+    /// The chapter's name.
+    pub name: String,
+    /// The chapter's contents.
+    pub content: String,
+    /// The chapter's section number, if it has one.
+    pub number: Option<SectionNumber>,
+    /// Nested items.
+    pub sub_items: Vec<BookItem>,
+}
+
+impl VirtualChapter {
+    /// Create a new chapter with the provided content.
+    pub fn new(name: &str, content: String) -> VirtualChapter {
+        VirtualChapter {
+            name: name.to_string(),
+            content: content,
             ..Default::default()
         }
     }

--- a/src/book/book.rs
+++ b/src/book/book.rs
@@ -301,10 +301,6 @@ fn load_virtual_chapter<P: AsRef<Path>>(link: &VirtualLink, src_dir: P) -> Resul
     ch.sub_items = sub_items;
 
     Ok(ch)
-        /* TODO Open question: Do we really want to return a `Result<_>` here?
-         * Pro: Function would have almost signature as load_chapter()
-         * Con: We do not use it!
-         */
 }
 
 /// A depth-first iterator over the items in a book.

--- a/src/book/book.rs
+++ b/src/book/book.rs
@@ -246,7 +246,7 @@ fn load_summary_item<P: AsRef<Path>>(
             load_chapter(link, src_dir, parent_names).map(|c| BookItem::Chapter(c))
         }
         SummaryItem::VirtualLink(ref link) =>
-            load_virtual_chapter(link, src_dir).map(VirtualChapter::into),
+            load_virtual_chapter(link, src_dir, parent_names).map(VirtualChapter::into),
     }
 }
 
@@ -290,7 +290,7 @@ fn load_chapter<P: AsRef<Path>>(
     Ok(ch)
 }
 
-fn load_virtual_chapter<P: AsRef<Path>>(link: &VirtualLink, src_dir: P) -> Result<VirtualChapter> {
+fn load_virtual_chapter<P: AsRef<Path>>(link: &VirtualLink, src_dir: P, parent_names: Vec<String>) -> Result<VirtualChapter> {
     let src_dir = src_dir.as_ref();
 
     let mut ch = VirtualChapter::new(&link.name);
@@ -298,7 +298,7 @@ fn load_virtual_chapter<P: AsRef<Path>>(link: &VirtualLink, src_dir: P) -> Resul
 
     let sub_items = link.nested_items
         .iter()
-        .map(|i| load_summary_item(i, src_dir))
+        .map(|i| load_summary_item(i, src_dir, parent_names.clone()))
         .collect::<Result<Vec<_>>>()?;
 
     ch.sub_items = sub_items;

--- a/src/book/book.rs
+++ b/src/book/book.rs
@@ -291,6 +291,7 @@ fn load_chapter<P: AsRef<Path>>(
 }
 
 fn load_virtual_chapter<P: AsRef<Path>>(link: &VirtualLink, src_dir: P, parent_names: Vec<String>) -> Result<VirtualChapter> {
+    debug!("Loading {}", link.name);
     let src_dir = src_dir.as_ref();
 
     let mut ch = VirtualChapter::new(&link.name);
@@ -324,11 +325,20 @@ impl<'a> Iterator for BookItems<'a> {
     fn next(&mut self) -> Option<Self::Item> {
         let item = self.items.pop_front();
 
-        if let Some(&BookItem::Chapter(ref ch)) = item {
-            // if we wanted a breadth-first iterator we'd `extend()` here
-            for sub_item in ch.sub_items.iter().rev() {
-                self.items.push_front(sub_item);
+        match item {
+            Some(&BookItem::Chapter(ref ch)) => {
+                // if we wanted a breadth-first iterator we'd `extend()` here
+                for sub_item in ch.sub_items.iter().rev() {
+                    self.items.push_front(sub_item);
+                }
+            },
+            Some(&BookItem::VirtualChapter(ref ch)) => {
+                // if we wanted a breadth-first iterator we'd `extend()` here
+                for sub_item in ch.sub_items.iter().rev() {
+                    self.items.push_front(sub_item);
+                }
             }
+            _ => {},
         }
 
         item

--- a/src/book/book.rs
+++ b/src/book/book.rs
@@ -189,8 +189,6 @@ impl Chapter {
 pub struct VirtualChapter {
     /// The chapter's name.
     pub name: String,
-    /// The chapter's contents.
-    pub content: String,
     /// The chapter's section number, if it has one.
     pub number: Option<SectionNumber>,
     /// Nested items.
@@ -198,11 +196,10 @@ pub struct VirtualChapter {
 }
 
 impl VirtualChapter {
-    /// Create a new chapter with the provided content.
-    pub fn new(name: &str, content: String) -> Self {
+    /// Create a new virtual chapter with the given name.
+    pub fn new(name: &str) -> Self {
         Self {
             name: name.to_string(),
-            content: content,
             ..Default::default()
         }
     }
@@ -293,12 +290,7 @@ fn load_chapter<P: AsRef<Path>>(
 fn load_virtual_chapter<P: AsRef<Path>>(link: &VirtualLink, src_dir: P) -> Result<VirtualChapter> {
     let src_dir = src_dir.as_ref();
 
-    let content = String::new();
-        /* TODO Open question: Do we need "pseudo content" for virtual chapters?
-         * If not: Remove this and corresponding field in `VirtualChapter`!
-         */
-
-    let mut ch = VirtualChapter::new(&link.name, content);
+    let mut ch = VirtualChapter::new(&link.name);
     ch.number = link.number.clone();
 
     let sub_items = link.nested_items

--- a/src/book/mod.rs
+++ b/src/book/mod.rs
@@ -109,6 +109,7 @@ impl MDBook {
     ///         BookItem::Chapter(ref chapter) => {},
     ///         BookItem::VirtualChapter(ref virtual_chapter) => {},
     ///         BookItem::Separator => {},
+    ///         _ => {},
     ///     }
     /// }
     ///

--- a/src/book/mod.rs
+++ b/src/book/mod.rs
@@ -107,6 +107,7 @@ impl MDBook {
     /// for item in book.iter() {
     ///     match *item {
     ///         BookItem::Chapter(ref chapter) => {},
+    ///         BookItem::VirtualChapter(ref virtual_chapter) => {},
     ///         BookItem::Separator => {},
     ///     }
     /// }

--- a/src/book/summary.rs
+++ b/src/book/summary.rs
@@ -79,8 +79,8 @@ pub struct Link {
 
 impl Link {
     /// Create a new link with no nested items.
-    pub fn new<S: Into<String>, P: AsRef<Path>>(name: S, location: P) -> Link {
-        Link {
+    pub fn new<S: Into<String>, P: AsRef<Path>>(name: S, location: P) -> Self {
+        Self {
             name: name.into(),
             location: location.as_ref().to_path_buf(),
             number: None,
@@ -91,7 +91,7 @@ impl Link {
 
 impl Default for Link {
     fn default() -> Self {
-        Link {
+        Self {
             name: String::new(),
             location: PathBuf::new(),
             number: None,
@@ -115,8 +115,8 @@ pub struct VirtualLink {
 
 impl VirtualLink {
     /// Create a new virtual link with no nested items.
-    pub fn new<S: Into<String>>(name: S) -> VirtualLink {
-        VirtualLink {
+    pub fn new<S: Into<String>>(name: S) -> Self {
+        Self {
             name: name.into(),
             number: None,
             nested_items: Vec::new(),
@@ -126,7 +126,7 @@ impl VirtualLink {
 
 impl Default for VirtualLink {
     fn default() -> Self {
-        VirtualLink {
+        Self {
             name: String::new(),
             number: None,
             nested_items: Vec::new(),
@@ -163,13 +163,13 @@ impl SummaryItem {
 }
 
 impl From<Link> for SummaryItem {
-    fn from(other: Link) -> SummaryItem {
+    fn from(other: Link) -> Self {
         SummaryItem::Link(other)
     }
 }
 
 impl From<VirtualLink> for SummaryItem {
-    fn from(other: VirtualLink) -> SummaryItem {
+    fn from(other: VirtualLink) -> Self {
         SummaryItem::VirtualLink(other)
     }
 }

--- a/src/book/summary.rs
+++ b/src/book/summary.rs
@@ -307,7 +307,7 @@ impl<'a> SummaryParser<'a> {
                         bail!(self.parse_error("Suffix chapters cannot be followed by a list"));
                     }
                 }
-                Some(Event::Start(Tag::Link(href, _))) => items.push(self.parse_item(href)),
+                Some(Event::Start(Tag::Link(href, _))) => items.push(self.parse_linklike(href)),
                 Some(Event::Start(Tag::Rule)) => items.push(SummaryItem::Separator),
                 Some(_) => {}
                 None => break,
@@ -317,7 +317,7 @@ impl<'a> SummaryParser<'a> {
         Ok(items)
     }
 
-    fn parse_item(&mut self, href: Cow<'a, str>) -> SummaryItem {
+    fn parse_linklike(&mut self, href: Cow<'a, str>) -> SummaryItem {
         let name = {
             let link_content = collect_events!(self.stream, end Tag::Link(..));
             stringify_events(link_content)
@@ -456,7 +456,7 @@ impl<'a> SummaryParser<'a> {
             match self.next_event() {
                 Some(Event::Start(Tag::Paragraph)) => continue,
                 Some(Event::Start(Tag::Link(href, _))) => {
-                    let mut item = self.parse_item(href);
+                    let mut item = self.parse_linklike(href);
 
                     let mut number = parent.clone();
                     number.0.push(num_existing_items as u32 + 1);
@@ -714,7 +714,7 @@ mod tests {
             other => panic!("Unreachable, {:?}", other),
         };
 
-        let got = parser.parse_item(href);
+        let got = parser.parse_linklike(href);
         assert_eq!(got, should_be);
     }
 
@@ -736,7 +736,7 @@ mod tests {
             other => panic!("Unreachable, {:?}", other),
         };
 
-        let got = parser.parse_item(href);
+        let got = parser.parse_linklike(href);
         assert_eq!(got, should_be);
     }
 

--- a/src/renderer/html_handlebars/hbs_renderer.rs
+++ b/src/renderer/html_handlebars/hbs_renderer.rs
@@ -435,7 +435,11 @@ fn make_data(root: &Path, book: &Book, config: &Config, html_config: &HtmlConfig
                 chapter.insert("path".to_owned(), json!(path));
             }
             BookItem::VirtualChapter(ref ch) => {
-                unimplemented!();   // TODO
+                if let Some(ref section) = ch.number {
+                    chapter.insert("section".to_owned(), json!(section.to_string()));
+                }
+
+                chapter.insert("name".to_owned(), json!(ch.name));
             }
             BookItem::Separator => {
                 chapter.insert("spacer".to_owned(), json!("_spacer_"));

--- a/src/renderer/html_handlebars/hbs_renderer.rs
+++ b/src/renderer/html_handlebars/hbs_renderer.rs
@@ -434,6 +434,9 @@ fn make_data(root: &Path, book: &Book, config: &Config, html_config: &HtmlConfig
                     .chain_err(|| "Could not convert path to str")?;
                 chapter.insert("path".to_owned(), json!(path));
             }
+            BookItem::VirtualChapter(ref ch) => {
+                unimplemented!();   // TODO
+            }
             BookItem::Separator => {
                 chapter.insert("spacer".to_owned(), json!("_spacer_"));
             }

--- a/src/renderer/html_handlebars/hbs_renderer.rs
+++ b/src/renderer/html_handlebars/hbs_renderer.rs
@@ -440,6 +440,7 @@ fn make_data(root: &Path, book: &Book, config: &Config, html_config: &HtmlConfig
             BookItem::Separator => {
                 chapter.insert("spacer".to_owned(), json!("_spacer_"));
             }
+            _ => unimplemented!(),
         }
 
         chapters.push(chapter);


### PR DESCRIPTION
**Beware:** This is currently WIP.

This pull request introduces virtual chapters which do not correspondent to a file on disk. Virtual chapters can be used for namespacing purposes since they have an entry in the `SUMMARY.md` and the rendered navigation on the left side.

Work to be done:
- [X] Add a variant to `BookItem` and `SummaryItem`.
- [ ] Modify the parser.
  - [X] Syntax A: `- [Some virtual chapter]()`
  - [ ] Syntax B: `- Some virtual chapter` if desired (**Design decision pending!**)
- [ ] Modify the renderer.
- [ ] Add test cases.
- [ ] Adjust the crate documentation.
- [ ] Write a passage for the user guide. 

Closes #483.
Closes #576.