### PR TITLE
Inline footnotes

### DIFF
--- a/src/theme/book.css
+++ b/src/theme/book.css
@@ -47,6 +47,17 @@ table td {
 table thead td {
   font-weight: 700;
 }
+:not(.footnote-definition) + .footnote-definition,
+.footnote-definition + :not(.footnote-definition) {
+  margin-top: 2em;
+}
+.footnote-definition {
+  font-size: 0.9em;
+  margin: 0.5em 0;
+}
+.footnote-definition p {
+  display: inline;
+}
 .sidebar {
   position: fixed;
   left: 0;

--- a/src/theme/stylus/general.styl
+++ b/src/theme/stylus/general.styl
@@ -48,3 +48,15 @@ table {
       td { font-weight: 700; }
     }
 }
+
+:not(.footnote-definition) + .footnote-definition,
+.footnote-definition + :not(.footnote-definition) {
+    margin-top: 2em;
+}
+
+.footnote-definition {
+    font-size: 0.9em;
+    margin: 0.5em 0;
+
+    p { display: inline; }
+}


### PR DESCRIPTION
Footnotes are inlined and made slightly smaller. Also, the first non-consecutive footnote has a bigger margin to the previous element. Fixes #210.

Rendered example:
![example](https://user-images.githubusercontent.com/3841359/35556690-368aa4da-05a3-11e8-902d-b58c4576d5db.png)

