### PR TITLE
Use relative links and translate internal references

### DIFF
--- a/book-example/src/cli/init.md
+++ b/book-example/src/cli/init.md
@@ -22,7 +22,7 @@ configuration files, etc.
 - The `book` directory is where your book is rendered. All the output is ready to be uploaded
 to a server to be seen by your audience.
 
-- The `SUMMARY.md` file is the most important file, it's the skeleton of your book and is discussed in more detail in another  [chapter](format/summary.html).
+- The `SUMMARY.md` file is the most important file, it's the skeleton of your book and is discussed in more detail in another  [chapter](../format/summary.md)
 
 #### Tip & Trick: Hidden Feature
 When a `SUMMARY.md` file already exists, the `init` command will first parse it and generate the missing files according to the paths used in the `SUMMARY.md`. This allows you to think and create the whole structure of your book and then let mdBook generate it for you.

--- a/book-example/src/for_developers/README.md
+++ b/book-example/src/for_developers/README.md
@@ -11,8 +11,8 @@ The *For Developers* chapters are here to show you the more advanced usage of
 
 The two main ways a developer can hook into the book's build process is via,
 
-- [Preprocessors](for_developers/preprocessors.html)
-- [Alternate Backends](for_developers/backends.html)
+- [Preprocessors](preprocessors.md)
+- [Alternate Backends](backends.md)
 
 
 ## The Build Process

--- a/src/renderer/html_handlebars/helpers/navigation.rs
+++ b/src/renderer/html_handlebars/helpers/navigation.rs
@@ -4,6 +4,8 @@ use std::collections::BTreeMap;
 use serde_json;
 use handlebars::{Context, Handlebars, Helper, RenderContext, RenderError, Renderable};
 
+use utils;
+
 type StringMap = BTreeMap<String, String>;
 
 /// Target for `find_chapter`.
@@ -87,6 +89,13 @@ fn render(
     trace!("Creating BTreeMap to inject in context");
 
     let mut context = BTreeMap::new();
+    let base_path = rc.evaluate_absolute("path", false)?
+                      .as_str()
+                      .ok_or_else(|| RenderError::new("Type error for `path`, string expected"))?
+                      .replace("\"", "");
+
+    context.insert("path_to_root".to_owned(),
+                                json!(utils::fs::path_to_root(&base_path)));
 
     chapter
         .get("name")

--- a/src/renderer/html_handlebars/helpers/toc.rs
+++ b/src/renderer/html_handlebars/helpers/toc.rs
@@ -1,6 +1,8 @@
 use std::path::Path;
 use std::collections::BTreeMap;
 
+use utils;
+
 use serde_json;
 use handlebars::{Handlebars, Helper, HelperDef, RenderContext, RenderError};
 use pulldown_cmark::{html, Event, Parser, Tag};
@@ -77,6 +79,7 @@ impl HelperDef for RenderToc {
                         .replace("\\", "/");
 
                     // Add link
+                    rc.writer.write_all(&utils::fs::path_to_root(&current).as_bytes())?;
                     rc.writer.write_all(tmp.as_bytes())?;
                     rc.writer.write_all(b"\"")?;
 

--- a/src/theme/book.js
+++ b/src/theme/book.js
@@ -293,9 +293,9 @@ function playpen_text(playpen) {
     var themePopup = document.getElementById('theme-list');
     var themeColorMetaTag = document.querySelector('meta[name="theme-color"]');
     var stylesheets = {
-        ayuHighlight: document.querySelector("[href='ayu-highlight.css']"),
-        tomorrowNight: document.querySelector("[href='tomorrow-night.css']"),
-        highlight: document.querySelector("[href='highlight.css']"),
+        ayuHighlight: document.querySelector("[href$='ayu-highlight.css']"),
+        tomorrowNight: document.querySelector("[href$='tomorrow-night.css']"),
+        highlight: document.querySelector("[href$='highlight.css']"),
     };
 
     function showThemes() {

--- a/src/theme/index.hbs
+++ b/src/theme/index.hbs
@@ -9,20 +9,18 @@
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <meta name="theme-color" content="#ffffff" />
 
-        <base href="{{ path_to_root }}">
-
-        <link rel="stylesheet" href="book.css">
+        <link rel="stylesheet" href="{{ path_to_root }}book.css">
         <link href="https://fonts.googleapis.com/css?family=Open+Sans:300italic,400italic,600italic,700italic,800italic,400,300,600,700,800" rel="stylesheet" type="text/css">
         <link href="https://fonts.googleapis.com/css?family=Source+Code+Pro:500" rel="stylesheet" type="text/css">
 
         <link rel="shortcut icon" href="{{ favicon }}">
 
         <!-- Font Awesome -->
-        <link rel="stylesheet" href="FontAwesome/css/font-awesome.css">
+        <link rel="stylesheet" href="{{ path_to_root }}FontAwesome/css/font-awesome.css">
 
-        <link rel="stylesheet" href="highlight.css">
-        <link rel="stylesheet" href="tomorrow-night.css">
-        <link rel="stylesheet" href="ayu-highlight.css">
+        <link rel="stylesheet" href="{{ path_to_root }}highlight.css">
+        <link rel="stylesheet" href="{{ path_to_root }}tomorrow-night.css">
+        <link rel="stylesheet" href="{{ path_to_root }}ayu-highlight.css">
 
         <!-- Custom theme stylesheets -->
         {{#each additional_css}}
@@ -107,7 +105,7 @@
                         <h1 class="menu-title">{{ book_title }}</h1> 
 
                         <div class="right-buttons">
-                            <a href="print.html" title="Print this book" aria-label="Print this book">
+                            <a href="{{ path_to_root }}print.html" title="Print this book" aria-label="Print this book">
                                 <i id="print-button" class="fa fa-print"></i>
                             </a>
                         </div>
@@ -144,13 +142,13 @@
                     <nav class="nav-wrapper" aria-label="Page navigation">
                         <!-- Mobile navigation buttons -->
                         {{#previous}}
-                            <a rel="prev" href="{{link}}" class="mobile-nav-chapters previous" title="Previous chapter" aria-label="Previous chapter" aria-keyshortcuts="Left">
+                            <a rel="prev" href="{{ path_to_root }}{{link}}" class="mobile-nav-chapters previous" title="Previous chapter" aria-label="Previous chapter" aria-keyshortcuts="Left">
                                 <i class="fa fa-angle-left"></i>
                             </a>
                         {{/previous}}
 
                         {{#next}}
-                            <a rel="next" href="{{link}}" class="mobile-nav-chapters next" title="Next chapter" aria-label="Next chapter" aria-keyshortcuts="Right">
+                            <a rel="next" href="{{ path_to_root }}{{link}}" class="mobile-nav-chapters next" title="Next chapter" aria-label="Next chapter" aria-keyshortcuts="Right">
                                 <i class="fa fa-angle-right"></i>
                             </a>
                         {{/next}}
@@ -162,13 +160,13 @@
 
             <nav class="nav-wide-wrapper" aria-label="Page navigation">
                 {{#previous}}
-                    <a href="{{link}}" class="nav-chapters previous" title="Previous chapter" aria-label="Previous chapter" aria-keyshortcuts="Left">
+                    <a href="{{ path_to_root }}{{link}}" class="nav-chapters previous" title="Previous chapter" aria-label="Previous chapter" aria-keyshortcuts="Left">
                         <i class="fa fa-angle-left"></i>
                     </a>
                 {{/previous}}
 
                 {{#next}}
-                    <a href="{{link}}" class="nav-chapters next" title="Next chapter" aria-label="Next chapter" aria-keyshortcuts="Right">
+                    <a href="{{ path_to_root }}{{link}}" class="nav-chapters next" title="Next chapter" aria-label="Next chapter" aria-keyshortcuts="Right">
                         <i class="fa fa-angle-right"></i>
                     </a>
                 {{/next}}
@@ -213,29 +211,32 @@
         {{/if}}
 
         {{#if playpen_js}}
-        <script src="ace.js" type="text/javascript" charset="utf-8"></script>
-        <script src="editor.js" type="text/javascript" charset="utf-8"></script>
-        <script src="mode-rust.js" type="text/javascript" charset="utf-8"></script>
-        <script src="theme-dawn.js" type="text/javascript" charset="utf-8"></script>
-        <script src="theme-tomorrow_night.js" type="text/javascript" charset="utf-8"></script>
+        <script src="{{ path_to_root }}ace.js" type="text/javascript" charset="utf-8"></script>
+        <script src="{{ path_to_root }}editor.js" type="text/javascript" charset="utf-8"></script>
+        <script src="{{ path_to_root }}mode-rust.js" type="text/javascript" charset="utf-8"></script>
+        <script src="{{ path_to_root }}theme-dawn.js" type="text/javascript" charset="utf-8"></script>
+        <script src="{{ path_to_root }}theme-tomorrow_night.js" type="text/javascript" charset="utf-8"></script>
         {{/if}}
 
         {{#if search_enabled}}
-        <script src="searchindex.js" type="text/javascript" charset="utf-8"></script>
+        <script src="{{ path_to_root }}searchindex.js" type="text/javascript" charset="utf-8"></script>
+        <script>
+            var path_to_root = "{{path_to_root}}";
+        </script>
         {{/if}}
         {{#if search_js}}
-        <script src="elasticlunr.min.js" type="text/javascript" charset="utf-8"></script>
-        <script src="mark.min.js" type="text/javascript" charset="utf-8"></script>
-        <script src="searcher.js" type="text/javascript" charset="utf-8"></script>
+        <script src="{{ path_to_root }}elasticlunr.min.js" type="text/javascript" charset="utf-8"></script>
+        <script src="{{ path_to_root }}mark.min.js" type="text/javascript" charset="utf-8"></script>
+        <script src="{{ path_to_root }}searcher.js" type="text/javascript" charset="utf-8"></script>
         {{/if}}
 
-        <script src="clipboard.min.js" type="text/javascript" charset="utf-8"></script>
-        <script src="highlight.js" type="text/javascript" charset="utf-8"></script>
-        <script src="book.js" type="text/javascript" charset="utf-8"></script>
+        <script src="{{ path_to_root }}clipboard.min.js" type="text/javascript" charset="utf-8"></script>
+        <script src="{{ path_to_root }}highlight.js" type="text/javascript" charset="utf-8"></script>
+        <script src="{{ path_to_root }}book.js" type="text/javascript" charset="utf-8"></script>
 
         <!-- Custom JS scripts -->
         {{#each additional_js}}
-        <script type="text/javascript" src="{{this}}"></script>
+        <script type="text/javascript" src="{{ path_to_root }}{{this}}"></script>
         {{/each}}
 
         {{#if is_print}}

--- a/src/theme/searcher/searcher.js
+++ b/src/theme/searcher/searcher.js
@@ -137,7 +137,7 @@ window.search = window.search || {};
             url.push("");
         }
 
-        return '<a href="' + url[0] + '?' + URL_MARK_PARAM + '=' + searchterms + '#' + url[1]
+        return '<a href="' + path_to_root + url[0] + '?' + URL_MARK_PARAM + '=' + searchterms + '#' + url[1]
             + '" aria-details="teaser_' + teaser_count + '">' + result.doc.breadcrumbs + '</a>'
             + '<span class="teaser" id="teaser_' + teaser_count + '" aria-label="Search Result Teaser">' 
             + teaser + '</span>';

--- a/src/theme/searcher/searcher.js
+++ b/src/theme/searcher/searcher.js
@@ -9,7 +9,14 @@ window.search = window.search || {};
     if (!Mark || !elasticlunr) {
         return;
     }
-    
+
+    //IE 11 Compatibility from https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/startsWith
+    if (!String.prototype.startsWith) {
+        String.prototype.startsWith = function(search, pos) {
+            return this.substr(!pos || pos < 0 ? 0 : +pos, search.length) === search;
+        };
+    }
+
     var search_wrap = document.getElementById('search-wrapper'),
         searchbar = document.getElementById('searchbar'),
         searchbar_outer = document.getElementById('searchbar-outer'),

--- a/tests/rendered_output.rs
+++ b/tests/rendered_output.rs
@@ -83,12 +83,11 @@ fn check_correct_cross_links_in_nested_dir() {
 
     let first = temp.path().join("book").join("first");
     let links = vec![
-        r#"<base href="../">"#,
-        r#"href="intro.html""#,
-        r#"href="first/index.html""#,
-        r#"href="first/nested.html""#,
-        r#"href="second.html""#,
-        r#"href="conclusion.html""#,
+        r#"href="../intro.html""#,
+        r#"href="../first/index.html""#,
+        r#"href="../first/nested.html""#,
+        r#"href="../second.html""#,
+        r#"href="../conclusion.html""#,
     ];
 
     let files_in_nested_dir = vec!["index.html", "nested.html"];
@@ -100,14 +99,14 @@ fn check_correct_cross_links_in_nested_dir() {
     assert_contains_strings(
         first.join("index.html"),
         &[
-            r##"href="first/index.html#some-section" id="some-section""##,
+            r##"href="#some-section" id="some-section""##,
         ],
     );
 
     assert_contains_strings(
         first.join("nested.html"),
         &[
-            r##"href="first/nested.html#some-section" id="some-section""##,
+            r##"href="#some-section" id="some-section""##,
         ],
     );
 }
@@ -367,8 +366,8 @@ fn by_default_mdbook_use_index_preprocessor_to_convert_readme_to_index() {
         .join("first")
         .join("index.html");
     let expected_strings = vec![
-        r#"href="first/index.html""#,
-        r#"href="second/index.html""#,
+        r#"href="../first/index.html""#,
+        r#"href="../second/index.html""#,
         "First README",
     ];
     assert_contains_strings(&first_index, &expected_strings);


### PR DESCRIPTION
So this PR is a breaking change.  This converts everything to a relative URL, and also resolves internal links, solving https://github.com/rust-lang-nursery/mdBook/issues/408.

This does two things:

## Making all the links relative within the output html

Currently the html output relies heavily on the `<base href`  for links.  This PR basically removes this from the template, and converts all links to relative, adding in the appropriate `path_to_root` variable.

Removing this has the following benefits:

* Images work on non-root URLs I.e, `http://example.com/book/`.
* A lot of workarounds can be stripped out: anchors and the index page come to mind.
* It enables the ability to convert internal links as per below

## Converting internal links from `.md` to `.html`

This is the second part of the change, and does break the internal structure of some books, but fixes https://github.com/rust-lang-nursery/mdBook/issues/408.

As an example in the`book-example` dir on the [init.md](https://github.com/rust-lang-nursery/mdBook/blob/master/book-example/src/cli/init.md) page, the following link:

```
[chapter](format/summary.html)
```

Is now changed to:

```
[chapter](../format/summary.md). 
```

This has the following benefits:

* Viewing this new file on github, you can click on it and it will go to that file, rather than giving you a 404
* This extends to editors such as vscode, which can follow links as per normal
* This also extends to other markdown generators like [mkdocs](http://www.mkdocs.org/), which use this method already.
* It keeps the links consistent to what you are writing in `SUMMARY.md`.
