### PR TITLE
Contain scrolling to the sidebar

### DIFF
--- a/src/theme/book.css
+++ b/src/theme/book.css
@@ -71,6 +71,7 @@ table thead td {
   -moz-box-sizing: border-box;
   box-sizing: border-box;
   -webkit-overflow-scrolling: touch;
+  overscroll-behavior-y: contain;
   -webkit-transition: -webkit-transform 0.5s;
   -moz-transition: -moz-transform 0.5s;
   -o-transition: -o-transform 0.5s;

--- a/src/theme/stylus/sidebar.styl
+++ b/src/theme/stylus/sidebar.styl
@@ -11,6 +11,7 @@
     font-size: 0.875em
     box-sizing: border-box
     -webkit-overflow-scrolling: touch
+    overscroll-behavior-y: contain;
 
     // Animation: slide away
     transition: transform 0.5s


### PR DESCRIPTION
> A position fixed left navigation bar does not want to hand off scrolling to the document because a scroll gesture performed on the navigation bar is almost never meant to scroll the document. In this case, the author can use contain on the sidebar to prevent scrolling from being chained to the parent document element.

https://wicg.github.io/overscroll-behavior/#motivating-examples