### PR TITLE
Use `git config` to get author name in `mdbook init`

### DIFF
--- a/src/bin/init.rs
+++ b/src/bin/init.rs
@@ -72,15 +72,13 @@ pub fn execute(args: &ArgMatches) -> Result<()> {
 fn get_author_name() -> Option<String> {
     let output = Command::new("git")
         .args(&["config", "--get", "user.name"])
-        .output();
+        .output()
+        .ok()?;
 
-    match output {
-        Ok(output) => if output.status.success() {
-            Some(String::from_utf8_lossy(&output.stdout).trim().to_owned())
-        } else {
-            None
-        },
-        _ => return None,
+    if output.status.success() {
+        Some(String::from_utf8_lossy(&output.stdout).trim().to_owned())
+    } else {
+        None
     }
 }
 

--- a/src/bin/init.rs
+++ b/src/bin/init.rs
@@ -68,17 +68,19 @@ pub fn execute(args: &ArgMatches) -> Result<()> {
     Ok(())
 }
 
-/// Obtains author name from git config file by running the `git config` command
+/// Obtains author name from git config file by running the `git config` command.
 fn get_author_name() -> Option<String> {
     let output = Command::new("git")
         .args(&["config", "--get", "user.name"])
-        .output()
-        .expect("failed to get user.name from git config");
+        .output();
 
-    if output.status.success() {
-        Some(String::from_utf8_lossy(&output.stdout).trim().to_owned())
-    } else {
-        None
+    match output {
+        Ok(output) => if output.status.success() {
+            Some(String::from_utf8_lossy(&output.stdout).trim().to_owned())
+        } else {
+            None
+        },
+        _ => return None,
     }
 }
 

--- a/src/bin/init.rs
+++ b/src/bin/init.rs
@@ -1,6 +1,6 @@
 use std::io;
 use std::io::Write;
-use std::env;
+use std::process::Command;
 use clap::{App, ArgMatches, SubCommand};
 use mdbook::MDBook;
 use mdbook::errors::Result;
@@ -68,20 +68,15 @@ pub fn execute(args: &ArgMatches) -> Result<()> {
     Ok(())
 }
 
-/// Obtains author name from git config file if it can be located.
+/// Obtains author name from git config file by running the `git config` command
 fn get_author_name() -> Option<String> {
-    if let Some(home) = env::home_dir() {
-        let git_config_path = home.join(".gitconfig");
-        let content = utils::fs::file_to_string(git_config_path).unwrap();
-        let user_name = content
-            .lines()
-            .filter(|x| !x.starts_with("#"))
-            .map(|x| x.trim_left())
-            .filter(|x| x.starts_with("name"))
-            .next();
-        user_name
-            .and_then(|x| x.rsplit("=").next())
-            .map(|x| x.trim().to_owned())
+    let output = Command::new("git")
+        .args(&["config", "--get", "user.name"])
+        .output()
+        .expect("failed to get user.name from git config");
+
+    if output.status.success() {
+        Some(String::from_utf8_lossy(&output.stdout).trim().to_owned())
     } else {
         None
     }


### PR DESCRIPTION
I was getting panics while trying to run `mdbook init` and located the issue being that I don't store my global git config in `~/.gitconfig` so I changed this function to call `git config` instead.

`git config` will automatically find the correct config file using it's preferred method (https://git-scm.com/docs/git-config#FILES)