### PR TITLE
Prevent search from triggering when editing code

### DIFF
--- a/src/theme/searcher/searcher.js
+++ b/src/theme/searcher/searcher.js
@@ -297,7 +297,7 @@ window.search = window.search || {};
     
     // Eventhandler for keyevents on `document`
     function globalKeyHandler(e) {
-        if (e.altKey || e.ctrlKey || e.metaKey || e.shiftKey) { return; }
+        if (e.altKey || e.ctrlKey || e.metaKey || e.shiftKey || e.target.type === 'textarea') { return; }
 
         if (e.keyCode == ESCAPE_KEYCODE) {
             e.preventDefault();


### PR DESCRIPTION
Heyo 👋 

I was playing with the interactive code editor in Rust By Example: https://rustbyexample.com/primitives/tuples.html when I noticed that typing `s` would bring up search and prevent me from coding with the letter s.

So, I added a check that exits the search event handler if the event originated in a `<textarea />`. I could have checked for class `ace_text-input` but that might have made the code more brittle if someone would happen to change the class for styling purposes.