### PR TITLE
Add a note in MathJax documentation

### DIFF
--- a/book-example/src/format/mathjax.md
+++ b/book-example/src/format/mathjax.md
@@ -9,8 +9,12 @@ To enable MathJax, you need to add the `mathjax-support` key to your `book.toml`
 mathjax-support = true
 ```
 
->**Note:**  
+>**Note:**
 The usual delimiters MathJax uses are not yet supported. You can't currently use `$$ ... $$` as delimiters and the `\[ ... \]` delimiters need an extra backslash to work. Hopefully this limitation will be lifted soon.
+
+>**Note:**
+> When you use double backslashes in MathJax blocks (for example in commands such as `\begin{cases} \frac 1 2 \\ \frac 3 4 \end{cases}`) you need to add _two extra_ backslashes (e.g., `\begin{cases} \frac 1 2 \\\\ \frac 3 4 \end{cases}`).
+
 
 ### Inline equations
 Inline equations are delimited by `\\(` and `\\)`. So for example, to render the following inline equation \\( \int x dx = \frac{x^2}{2} + C \\) you would write the following:


### PR DESCRIPTION
There is a "hard to google" issue with some advanced math commands that uses double backslashes. I added a note in the documentation so that it is clear how to solve it. 