### PR TITLE
Replace his with their in reference to reader

### DIFF
--- a/src/theme/mod.rs
+++ b/src/theme/mod.rs
@@ -36,7 +36,7 @@ pub static FONT_AWESOME_OTF: &'static [u8] = include_bytes!("_FontAwesome/fonts/
 
 
 /// The `Theme` struct should be used instead of the static variables because
-/// the `new()` method will look if the user has a theme directory in his
+/// the `new()` method will look if the user has a theme directory in their
 /// source folder and use the users theme instead of the default.
 ///
 /// You should only ever use the static variables directly if you want to

--- a/src/theme/searcher/searcher.js
+++ b/src/theme/searcher/searcher.js
@@ -3,7 +3,7 @@ window.search = window.search || {};
     // Search functionality
     //
     // You can use !hasFocus() to prevent keyhandling in your key
-    // event handlers while the user is typing his search.
+    // event handlers while the user is typing their search.
 
     if (!Mark || !elasticlunr) {
         return;


### PR DESCRIPTION
It's good practice to not assume the gender of the reader or a hypothetical developer.  The simple fix is to replace instances of `his` with `their` and `him` with `them` or `the user`.

I did a simple search with `ripgrep` so I may have missed some instances, but  `his` only appears twice as far as I could tell, so I replaced both instances with `their`.