### PR TITLE
Fixes the search box overlapping with content when first shown

### DIFF
--- a/src/theme/book.css
+++ b/src/theme/book.css
@@ -1417,6 +1417,7 @@ mark.fade-out {
   margin-left: auto;
   margin-right: auto;
   max-width: 750px;
+  display: block;
 }
 #searchbar {
   width: 100%;

--- a/src/theme/stylus/searchbar.styl
+++ b/src/theme/stylus/searchbar.styl
@@ -21,6 +21,7 @@ mark.fade-out {
     margin-left: auto;
     margin-right: auto;
     max-width: $content-max-width;
+    display: block;
 }
 
 #searchbar {
@@ -64,3 +65,4 @@ ul#searchresults {
         font-style: normal;
     }
 }
+


### PR DESCRIPTION
When the sidebar is open and viewing full screen, the *empty* search box overlaps with page content.

![screenshot_2018-04-10_07-13-58](https://user-images.githubusercontent.com/17380079/38527738-03211e1c-3c8f-11e8-8ce9-d9bd49fb3a6a.png)

Making the `searchbox-outer` display as a `block` element *seems* to fix the issue.

![screenshot_2018-04-10_07-14-52](https://user-images.githubusercontent.com/17380079/38527791-35b29694-3c8f-11e8-9073-11455d533b7b.png)
