### PR TITLE
Improve print output

### DIFF
--- a/src/theme/book.css
+++ b/src/theme/book.css
@@ -1322,12 +1322,14 @@ html:not(.sidebar-visible) #menu-bar:not(:hover).folded > #menu-bar-sticky-conta
   .mobile-nav-chapters {
     display: none;
   }
-  #page-wrapper {
-    left: 0;
-    overflow-y: initial;
-  }
   #page-wrapper.page-wrapper {
-    padding-left: 0px;
+    -webkit-transform: none;
+    -moz-transform: none;
+    -o-transform: none;
+    -ms-transform: none;
+    transform: none;
+    margin-left: 0px;
+    overflow-y: initial;
   }
   #content {
     max-width: none;
@@ -1361,7 +1363,6 @@ html:not(.sidebar-visible) #menu-bar:not(:hover).folded > #menu-bar-sticky-conta
   h6 {
     page-break-inside: avoid;
     page-break-after: avoid;
-/*break-after: avoid*/
   }
   pre,
   code {

--- a/src/theme/book.css
+++ b/src/theme/book.css
@@ -1367,11 +1367,7 @@ html:not(.sidebar-visible) #menu-bar:not(:hover).folded > #menu-bar-sticky-conta
   pre,
   code {
     page-break-inside: avoid;
-    white-space: pre-wrap /* CSS 3 */;
-    white-space: -moz-pre-wrap /* Mozilla, since 1999 */;
-    white-space: -pre-wrap /* Opera 4-6 */;
-    white-space: -o-pre-wrap /* Opera 7 */;
-    word-wrap: break-word /* Internet Explorer 5.5+ */;
+    white-space: pre-wrap;
   }
   .fa {
     display: none !important;

--- a/src/theme/book.css
+++ b/src/theme/book.css
@@ -1373,6 +1373,9 @@ html:not(.sidebar-visible) #menu-bar:not(:hover).folded > #menu-bar-sticky-conta
     white-space: -o-pre-wrap /* Opera 7 */;
     word-wrap: break-word /* Internet Explorer 5.5+ */;
   }
+  .fa {
+    display: none !important;
+  }
 }
 .tooltiptext {
   position: absolute;

--- a/src/theme/index.hbs
+++ b/src/theme/index.hbs
@@ -212,14 +212,6 @@
         </script>
         {{/if}}
 
-        {{#if is_print}}
-        <script type="text/javascript">
-            document.addEventListener('DOMContentLoaded', function() {
-                window.print();
-            })
-        </script>
-        {{/if}}
-
         {{#if playpen_js}}
         <script src="ace.js" type="text/javascript" charset="utf-8"></script>
         <script src="editor.js" type="text/javascript" charset="utf-8"></script>
@@ -245,6 +237,22 @@
         {{#each additional_js}}
         <script type="text/javascript" src="{{this}}"></script>
         {{/each}}
+
+        {{#if is_print}}
+        {{#if mathjax_support}}
+        <script type="text/x-mathjax-config">
+        MathJax.Hub.Register.StartupHook("End", function() {
+            window.print();
+        });
+        </script>
+        {{else}}
+        <script type="text/javascript">
+        document.addEventListener('DOMContentLoaded', function() {
+            window.print();
+        });
+        </script>
+        {{/if}}
+        {{/if}}
 
     </body>
 </html>

--- a/src/theme/index.hbs
+++ b/src/theme/index.hbs
@@ -240,7 +240,7 @@
 
         {{#if is_print}}
         {{#if mathjax_support}}
-        <script type="text/x-mathjax-config">
+        <script type="text/javascript">
         MathJax.Hub.Register.StartupHook("End", function() {
             window.print();
         });

--- a/src/theme/index.hbs
+++ b/src/theme/index.hbs
@@ -241,14 +241,16 @@
         {{#if is_print}}
         {{#if mathjax_support}}
         <script type="text/javascript">
-        MathJax.Hub.Register.StartupHook("End", function() {
-            window.print();
+        window.addEventListener('load', function() {
+            MathJax.Hub.Register.StartupHook('End', function() {
+                window.setTimeout(window.print, 100);
+            });
         });
         </script>
         {{else}}
         <script type="text/javascript">
-        document.addEventListener('DOMContentLoaded', function() {
-            window.print();
+        window.addEventListener('load', function() {
+            window.setTimeout(window.print, 100);
         });
         </script>
         {{/if}}

--- a/src/theme/stylus/print.styl
+++ b/src/theme/stylus/print.styl
@@ -47,11 +47,7 @@
 
     pre, code {
         page-break-inside: avoid
-        white-space: pre-wrap       /* CSS 3 */
-        white-space: -moz-pre-wrap  /* Mozilla, since 1999 */
-        white-space: -pre-wrap      /* Opera 4-6 */
-        white-space: -o-pre-wrap    /* Opera 7 */
-        word-wrap: break-word       /* Internet Explorer 5.5+ */
+        white-space: pre-wrap
     }
 
     .fa {

--- a/src/theme/stylus/print.styl
+++ b/src/theme/stylus/print.styl
@@ -7,13 +7,10 @@
         display: none
     }
 
-    #page-wrapper {
-        left: 0;
-        overflow-y: initial;
-    }
-
     #page-wrapper.page-wrapper {
-        padding-left: 0px;
+        transform: none;
+        margin-left: 0px;
+        overflow-y: initial;
     }
 
     #content {
@@ -46,7 +43,6 @@
     h1, h2, h3, h4, h5, h6 {
         page-break-inside: avoid
         page-break-after: avoid
-        /*break-after: avoid*/
     }
 
     pre, code {

--- a/src/theme/stylus/print.styl
+++ b/src/theme/stylus/print.styl
@@ -53,4 +53,8 @@
         white-space: -o-pre-wrap    /* Opera 7 */
         word-wrap: break-word       /* Internet Explorer 5.5+ */
     }
+
+    .fa {
+        display: none !important 
+    }
 }


### PR DESCRIPTION
Since #648, the content doesn't use `left`/`padding-left` to make room for the sidebar, instead using `transform`/`margin-left`. The print CSS wasn't updated for this change, so if the sidebar was visible it would push content to the right when printing.