### PR TITLE
Add `rewrite_to_dir` config to rewrite index file path

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -424,6 +424,8 @@ pub struct HtmlConfig {
     pub livereload_url: Option<String>,
     /// Should section labels be rendered?
     pub no_section_label: bool,
+    /// Filenames listed here would be rewritten to directory index `/`.
+    pub rewrite_to_dir: Vec<String>,
     /// Search settings. If `None`, the default will be used.
     pub search: Option<Search>,
 }

--- a/src/renderer/html_handlebars/hbs_renderer.rs
+++ b/src/renderer/html_handlebars/hbs_renderer.rs
@@ -219,7 +219,10 @@ impl HtmlHandlebars {
     }
 
     fn register_hbs_helpers(&self, handlebars: &mut Handlebars, html_config: &HtmlConfig) {
-        handlebars.register_helper("toc", Box::new(helpers::toc::RenderToc {no_section_label: html_config.no_section_label}));
+        handlebars.register_helper("toc", Box::new(helpers::toc::RenderToc {
+            no_section_label: html_config.no_section_label,
+            rewrite_to_dir: html_config.rewrite_to_dir.to_owned(),
+        }));
         handlebars.register_helper("previous", Box::new(helpers::navigation::previous));
         handlebars.register_helper("next", Box::new(helpers::navigation::next));
     }

--- a/src/renderer/html_handlebars/hbs_renderer.rs
+++ b/src/renderer/html_handlebars/hbs_renderer.rs
@@ -219,12 +219,17 @@ impl HtmlHandlebars {
     }
 
     fn register_hbs_helpers(&self, handlebars: &mut Handlebars, html_config: &HtmlConfig) {
+        let HtmlConfig { no_section_label, ref rewrite_to_dir, .. } = *html_config;
         handlebars.register_helper("toc", Box::new(helpers::toc::RenderToc {
-            no_section_label: html_config.no_section_label,
-            rewrite_to_dir: html_config.rewrite_to_dir.to_owned(),
+            no_section_label,
+            rewrite_to_dir: rewrite_to_dir.to_owned(),
         }));
-        handlebars.register_helper("previous", Box::new(helpers::navigation::previous));
-        handlebars.register_helper("next", Box::new(helpers::navigation::next));
+        handlebars.register_helper("previous", Box::new(helpers::navigation::Previous {
+            rewrite_to_dir: rewrite_to_dir.to_owned(),
+        }));
+        handlebars.register_helper("next", Box::new(helpers::navigation::Next {
+            rewrite_to_dir: rewrite_to_dir.to_owned(),
+        }));
     }
 
     /// Copy across any additional CSS and JavaScript files which the book

--- a/src/renderer/html_handlebars/helpers/mod.rs
+++ b/src/renderer/html_handlebars/helpers/mod.rs
@@ -1,2 +1,38 @@
+use std::path::{Path, PathBuf};
+
 pub mod toc;
 pub mod navigation;
+
+/// Rewrite filename of path to directory index if matches any of filename
+/// pattern in `rewrite_names`.
+///
+/// * `path` - Path reference.
+/// * `rewrite_names` - Array of filename pattern to be rewritten.
+pub fn rewrite_to_dir_index<P: AsRef<Path>>(path: P, rewrite_names: &[String]) -> PathBuf {
+    let p = path.as_ref();
+    for name in rewrite_names.iter() {
+        if name.as_str() == p.file_name().unwrap_or_default() {
+            return p.with_file_name("");
+        }
+    }
+    return p.to_owned();
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn rewrite_to_dir_success() {
+        let names = vec!["index.html".to_owned(), "index.md".to_owned()];
+
+        let path = PathBuf::from("index.html");
+        assert_eq!(rewrite_to_dir_index(&path, &names), PathBuf::from(""));
+
+        let path = PathBuf::from("index.md");
+        assert_eq!(rewrite_to_dir_index(&path, &names), PathBuf::from(""));
+
+        let path = PathBuf::from("index.asp");
+        assert_eq!(rewrite_to_dir_index(&path, &names), path);
+    }
+}


### PR DESCRIPTION
## The PR is for

Rewrite specified filename of URLs to directory index `/`.

## Intent

Need cleans URL for sharing article and chapters.  File paths of `index.html` are redundant.

## Details

Add a new config field `rewrite-to-dir` under `[output.html]`. This field accepts `Vec<String>` of filename. Take an example:

```toml
[output.html]
mathjax-support = true
no-section-label = true
rewrite-to-dir = ["index.html"]
```

This configuration only affects TOC and navigations without touch any contents.



