### PR TITLE
Remove rustfmt.toml

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -24,7 +24,6 @@ mod execs {
     }
 }
 
-
 error_chain!{
  foreign_links {
         Io(std::io::Error);
@@ -32,23 +31,25 @@ error_chain!{
 }
 
 fn program_exists(program: &str) -> Result<()> {
-    execs::cmd(program).arg("-v")
-                       .output()
-                       .chain_err(|| format!("Please install '{}'!", program))?;
+    execs::cmd(program)
+        .arg("-v")
+        .output()
+        .chain_err(|| format!("Please install '{}'!", program))?;
     Ok(())
 }
 
 fn npm_package_exists(package: &str) -> Result<()> {
-    let status = execs::cmd("npm").args(&["list", "-g"])
-                                  .arg(package)
-                                  .output();
+    let status = execs::cmd("npm")
+        .args(&["list", "-g"])
+        .arg(package)
+        .output();
 
     match status {
         Ok(ref out) if out.status.success() => Ok(()),
-        _ => {
-            bail!("Missing npm package '{0}' install with: 'npm -g install {0}'",
-                  package)
-        }
+        _ => bail!(
+            "Missing npm package '{0}' install with: 'npm -g install {0}'",
+            package
+        ),
     }
 }
 
@@ -81,13 +82,14 @@ fn run() -> Result<()> {
         let theme_dir = Path::new(&manifest_dir).join("src/theme/");
         let stylus_dir = theme_dir.join("stylus/book.styl");
 
-        if !execs::cmd("stylus").arg(stylus_dir)
-                                .arg("--out")
-                                .arg(theme_dir)
-                                .arg("--use")
-                                .arg("nib")
-                                .status()?
-                                .success()
+        if !execs::cmd("stylus")
+            .arg(stylus_dir)
+            .arg("--out")
+            .arg(theme_dir)
+            .arg("--use")
+            .arg("nib")
+            .status()?
+            .success()
         {
             bail!("Stylus encountered an error");
         }

--- a/examples/de-emphasize.rs
+++ b/examples/de-emphasize.rs
@@ -3,15 +3,15 @@ extern crate mdbook;
 extern crate pulldown_cmark;
 extern crate pulldown_cmark_to_cmark;
 
-use mdbook::errors::{Error, Result};
-use mdbook::MDBook;
 use mdbook::book::{Book, BookItem, Chapter};
+use mdbook::errors::{Error, Result};
 use mdbook::preprocess::{Preprocessor, PreprocessorContext};
+use mdbook::MDBook;
 use pulldown_cmark::{Event, Parser, Tag};
 use pulldown_cmark_to_cmark::fmt::cmark;
 
-use std::ffi::OsString;
 use std::env::{args, args_os};
+use std::ffi::OsString;
 use std::process;
 
 struct Deemphasize;

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,1 +1,0 @@
-format_strings = true

--- a/src/bin/build.rs
+++ b/src/bin/build.rs
@@ -1,7 +1,7 @@
-use std::path::PathBuf;
 use clap::{App, ArgMatches, SubCommand};
-use mdbook::MDBook;
 use mdbook::errors::Result;
+use mdbook::MDBook;
+use std::path::PathBuf;
 use {get_book_dir, open};
 
 // Create clap subcommand arguments

--- a/src/bin/clean.rs
+++ b/src/bin/clean.rs
@@ -1,9 +1,9 @@
+use clap::{App, ArgMatches, SubCommand};
+use get_book_dir;
+use mdbook::errors::*;
+use mdbook::MDBook;
 use std::fs;
 use std::path::PathBuf;
-use clap::{App, ArgMatches, SubCommand};
-use mdbook::MDBook;
-use mdbook::errors::*;
-use get_book_dir;
 
 // Create clap subcommand arguments
 pub fn make_subcommand<'a, 'b>() -> App<'a, 'b> {

--- a/src/bin/init.rs
+++ b/src/bin/init.rs
@@ -1,11 +1,11 @@
+use clap::{App, ArgMatches, SubCommand};
+use get_book_dir;
+use mdbook::config;
+use mdbook::errors::Result;
+use mdbook::MDBook;
 use std::io;
 use std::io::Write;
 use std::process::Command;
-use clap::{App, ArgMatches, SubCommand};
-use mdbook::MDBook;
-use mdbook::errors::Result;
-use mdbook::config;
-use get_book_dir;
 
 // Create clap subcommand arguments
 pub fn make_subcommand<'a, 'b>() -> App<'a, 'b> {

--- a/src/bin/mdbook.rs
+++ b/src/bin/mdbook.rs
@@ -8,22 +8,22 @@ extern crate log;
 extern crate mdbook;
 extern crate open;
 
+use chrono::Local;
+use clap::{App, AppSettings, ArgMatches};
+use env_logger::Builder;
+use log::LevelFilter;
+use mdbook::utils;
 use std::env;
 use std::ffi::OsStr;
-use std::path::{Path, PathBuf};
 use std::io::Write;
-use clap::{App, AppSettings, ArgMatches};
-use chrono::Local;
-use log::LevelFilter;
-use env_logger::Builder;
-use mdbook::utils;
+use std::path::{Path, PathBuf};
 
 pub mod build;
 pub mod clean;
 pub mod init;
-pub mod test;
 #[cfg(feature = "serve")]
 pub mod serve;
+pub mod test;
 #[cfg(feature = "watch")]
 pub mod watch;
 

--- a/src/bin/serve.rs
+++ b/src/bin/serve.rs
@@ -2,16 +2,17 @@ extern crate iron;
 extern crate staticfile;
 extern crate ws;
 
-use std;
-use self::iron::{status, AfterMiddleware, Chain, Iron, IronError, IronResult, Request, Response,
-                 Set};
+use self::iron::{
+    status, AfterMiddleware, Chain, Iron, IronError, IronResult, Request, Response, Set,
+};
 use clap::{App, ArgMatches, SubCommand};
-use mdbook::MDBook;
-use mdbook::utils;
 use mdbook::errors::*;
-use {get_book_dir, open};
+use mdbook::utils;
+use mdbook::MDBook;
+use std;
 #[cfg(feature = "watch")]
 use watch;
+use {get_book_dir, open};
 
 struct ErrorRecover;
 

--- a/src/bin/test.rs
+++ b/src/bin/test.rs
@@ -1,22 +1,20 @@
 use clap::{App, ArgMatches, SubCommand};
-use mdbook::MDBook;
-use mdbook::errors::Result;
 use get_book_dir;
+use mdbook::errors::Result;
+use mdbook::MDBook;
 
 // Create clap subcommand arguments
 pub fn make_subcommand<'a, 'b>() -> App<'a, 'b> {
     SubCommand::with_name("test")
         .about("Test that code samples compile")
-        .arg_from_usage(
-            "-L, --library-path [DIR]... 'directory to add to crate search path'",
-        )
+        .arg_from_usage("-L, --library-path [DIR]... 'directory to add to crate search path'")
 }
 
 // test command implementation
 pub fn execute(args: &ArgMatches) -> Result<()> {
     let library_paths: Vec<&str> = args.values_of("library-path")
-                                       .map(|v| v.collect())
-                                       .unwrap_or_default();
+        .map(|v| v.collect())
+        .unwrap_or_default();
     let book_dir = get_book_dir(args);
     let mut book = MDBook::load(&book_dir)?;
 

--- a/src/bin/watch.rs
+++ b/src/bin/watch.rs
@@ -1,13 +1,13 @@
 extern crate notify;
 
-use std::path::Path;
 use self::notify::Watcher;
-use std::time::Duration;
-use std::sync::mpsc::channel;
 use clap::{App, ArgMatches, SubCommand};
-use mdbook::MDBook;
-use mdbook::utils;
 use mdbook::errors::Result;
+use mdbook::utils;
+use mdbook::MDBook;
+use std::path::Path;
+use std::sync::mpsc::channel;
+use std::time::Duration;
 use {get_book_dir, open};
 
 // Create clap subcommand arguments
@@ -48,8 +48,8 @@ pub fn trigger_on_change<F>(book: &MDBook, closure: F)
 where
     F: Fn(&Path, &Path),
 {
-    use self::notify::RecursiveMode::*;
     use self::notify::DebouncedEvent::*;
+    use self::notify::RecursiveMode::*;
 
     // Create a channel to receive the events.
     let (tx, rx) = channel();

--- a/src/book/book.rs
+++ b/src/book/book.rs
@@ -1,8 +1,8 @@
-use std::fmt::{self, Display, Formatter};
-use std::path::{Path, PathBuf};
 use std::collections::VecDeque;
+use std::fmt::{self, Display, Formatter};
 use std::fs::{self, File};
 use std::io::{Read, Write};
+use std::path::{Path, PathBuf};
 
 use super::summary::{parse_summary, Link, SectionNumber, Summary, SummaryItem};
 use config::BuildConfig;
@@ -297,8 +297,8 @@ impl Display for Chapter {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use tempfile::{TempDir, Builder as TempFileBuilder};
     use std::io::Write;
+    use tempfile::{Builder as TempFileBuilder, TempDir};
 
     const DUMMY_SRC: &'static str = "
 # Dummy Chapter
@@ -404,14 +404,12 @@ And here is some \
             ..Default::default()
         };
         let should_be = Book {
-            sections: vec![
-                BookItem::Chapter(Chapter {
-                    name: String::from("Chapter 1"),
-                    content: String::from(DUMMY_SRC),
-                    path: PathBuf::from("chapter_1.md"),
-                    ..Default::default()
-                }),
-            ],
+            sections: vec![BookItem::Chapter(Chapter {
+                name: String::from("Chapter 1"),
+                content: String::from(DUMMY_SRC),
+                path: PathBuf::from("chapter_1.md"),
+                ..Default::default()
+            })],
             ..Default::default()
         };
 
@@ -535,13 +533,11 @@ And here is some \
     fn cant_load_chapters_with_an_empty_path() {
         let (_, temp) = dummy_link();
         let summary = Summary {
-            numbered_chapters: vec![
-                SummaryItem::Link(Link {
-                    name: String::from("Empty"),
-                    location: PathBuf::from(""),
-                    ..Default::default()
-                }),
-            ],
+            numbered_chapters: vec![SummaryItem::Link(Link {
+                name: String::from("Empty"),
+                location: PathBuf::from(""),
+                ..Default::default()
+            })],
             ..Default::default()
         };
 
@@ -556,13 +552,11 @@ And here is some \
         fs::create_dir(&dir).unwrap();
 
         let summary = Summary {
-            numbered_chapters: vec![
-                SummaryItem::Link(Link {
-                    name: String::from("nested"),
-                    location: dir,
-                    ..Default::default()
-                }),
-            ],
+            numbered_chapters: vec![SummaryItem::Link(Link {
+                name: String::from("nested"),
+                location: dir,
+                ..Default::default()
+            })],
             ..Default::default()
         };
 

--- a/src/book/init.rs
+++ b/src/book/init.rs
@@ -1,12 +1,12 @@
 use std::fs::{self, File};
-use std::path::PathBuf;
 use std::io::Write;
+use std::path::PathBuf;
 use toml;
 
-use config::Config;
 use super::MDBook;
-use theme;
+use config::Config;
 use errors::*;
+use theme;
 
 /// A helper for setting up a new book and its directory structure.
 #[derive(Debug, Clone, PartialEq)]

--- a/src/book/mod.rs
+++ b/src/book/mod.rs
@@ -5,29 +5,24 @@
 //!
 //! [1]: ../index.html
 
-mod summary;
 mod book;
 mod init;
+mod summary;
 
 pub use self::book::{load_book, Book, BookItem, BookItems, Chapter};
-pub use self::summary::{parse_summary, Link, SectionNumber, Summary, SummaryItem};
 pub use self::init::BookBuilder;
+pub use self::summary::{parse_summary, Link, SectionNumber, Summary, SummaryItem};
 
-use std::path::PathBuf;
 use std::io::Write;
+use std::path::PathBuf;
 use std::process::Command;
 use tempfile::Builder as TempFileBuilder;
 use toml::Value;
 
-use utils;
-use renderer::{CmdRenderer, HtmlHandlebars, RenderContext, Renderer};
-use preprocess::{
-    LinkPreprocessor,
-    IndexPreprocessor,
-    Preprocessor,
-    PreprocessorContext
-};
 use errors::*;
+use preprocess::{IndexPreprocessor, LinkPreprocessor, Preprocessor, PreprocessorContext};
+use renderer::{CmdRenderer, HtmlHandlebars, RenderContext, Renderer};
+use utils;
 
 use config::Config;
 

--- a/src/book/summary.rs
+++ b/src/book/summary.rs
@@ -1,10 +1,10 @@
+use errors::*;
+use memchr::{self, Memchr};
+use pulldown_cmark::{self, Event, Tag};
 use std::fmt::{self, Display, Formatter};
 use std::iter::FromIterator;
 use std::ops::{Deref, DerefMut};
 use std::path::{Path, PathBuf};
-use memchr::{self, Memchr};
-use pulldown_cmark::{self, Event, Tag};
-use errors::*;
 
 /// Parse the text from a `SUMMARY.md` file into a sort of "recipe" to be
 /// used when loading a book from disk.
@@ -164,33 +164,34 @@ struct SummaryParser<'a> {
 /// use pattern matching and you won't get errors because `take_while()`
 /// moves `$stream` out of self.
 macro_rules! collect_events {
-    ($stream:expr, start $delimiter:pat) => {
+    ($stream:expr,start $delimiter:pat) => {
         collect_events!($stream, Event::Start($delimiter))
     };
-    ($stream:expr, end $delimiter:pat) => {
+    ($stream:expr,end $delimiter:pat) => {
         collect_events!($stream, Event::End($delimiter))
     };
-    ($stream:expr, $delimiter:pat) => {
-        {
-            let mut events = Vec::new();
+    ($stream:expr, $delimiter:pat) => {{
+        let mut events = Vec::new();
 
-            loop {
-                let event = $stream.next();
-                trace!("Next event: {:?}", event);
+        loop {
+            let event = $stream.next();
+            trace!("Next event: {:?}", event);
 
-                match event {
-                    Some($delimiter) => break,
-                    Some(other) => events.push(other),
-                    None => {
-                        debug!("Reached end of stream without finding the closing pattern, {}", stringify!($delimiter));
-                        break;
-                    }
+            match event {
+                Some($delimiter) => break,
+                Some(other) => events.push(other),
+                None => {
+                    debug!(
+                        "Reached end of stream without finding the closing pattern, {}",
+                        stringify!($delimiter)
+                    );
+                    break;
                 }
             }
-
-            events
         }
-    }
+
+        events
+    }};
 }
 
 impl<'a> SummaryParser<'a> {
@@ -659,14 +660,12 @@ mod tests {
                 name: String::from("First"),
                 location: PathBuf::from("./first.md"),
                 number: Some(SectionNumber(vec![1])),
-                nested_items: vec![
-                    SummaryItem::Link(Link {
-                        name: String::from("Nested"),
-                        location: PathBuf::from("./nested.md"),
-                        number: Some(SectionNumber(vec![1, 1])),
-                        nested_items: Vec::new(),
-                    }),
-                ],
+                nested_items: vec![SummaryItem::Link(Link {
+                    name: String::from("Nested"),
+                    location: PathBuf::from("./nested.md"),
+                    number: Some(SectionNumber(vec![1, 1])),
+                    nested_items: Vec::new(),
+                })],
             }),
             SummaryItem::Link(Link {
                 name: String::from("Second"),

--- a/src/config.rs
+++ b/src/config.rs
@@ -50,17 +50,17 @@
 
 #![deny(missing_docs)]
 
-use std::path::{Path, PathBuf};
-use std::fs::File;
-use std::io::Read;
-use std::env;
-use toml::{self, Value};
-use toml::value::Table;
-use toml_query::read::TomlValueReadExt;
-use toml_query::insert::TomlValueInsertExt;
-use toml_query::delete::TomlValueDeleteExt;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use serde_json;
+use std::env;
+use std::fs::File;
+use std::io::Read;
+use std::path::{Path, PathBuf};
+use toml::value::Table;
+use toml::{self, Value};
+use toml_query::delete::TomlValueDeleteExt;
+use toml_query::insert::TomlValueInsertExt;
+use toml_query::read::TomlValueReadExt;
 
 use errors::*;
 
@@ -217,9 +217,10 @@ impl Config {
         // figure out what try_into() deserializes to.
         macro_rules! get_and_insert {
             ($table:expr, $key:expr => $out:expr) => {
-                let got = $table.as_table_mut()
-                                .and_then(|t| t.remove($key))
-                                .and_then(|v| v.try_into().ok());
+                let got = $table
+                    .as_table_mut()
+                    .and_then(|t| t.remove($key))
+                    .and_then(|v| v.try_into().ok());
                 if let Some(value) = got {
                     $out = value;
                 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -107,17 +107,17 @@ extern crate toml_query;
 #[macro_use]
 extern crate pretty_assertions;
 
-pub mod preprocess;
 pub mod book;
 pub mod config;
+pub mod preprocess;
 pub mod renderer;
 pub mod theme;
 pub mod utils;
 
-pub use book::MDBook;
 pub use book::BookItem;
-pub use renderer::Renderer;
+pub use book::MDBook;
 pub use config::Config;
+pub use renderer::Renderer;
 
 /// The error types used through out this crate.
 pub mod errors {

--- a/src/preprocess/index.rs
+++ b/src/preprocess/index.rs
@@ -1,5 +1,5 @@
-use std::path::Path;
 use regex::Regex;
+use std::path::Path;
 
 use errors::*;
 
@@ -27,8 +27,7 @@ impl Preprocessor for IndexPreprocessor {
         book.for_each_mut(|section: &mut BookItem| {
             if let BookItem::Chapter(ref mut ch) = *section {
                 if is_readme_file(&ch.path) {
-                    let index_md = source_dir
-                        .join(ch.path.with_file_name("index.md"));
+                    let index_md = source_dir.join(ch.path.with_file_name("index.md"));
                     if index_md.exists() {
                         warn_readme_name_conflict(&ch.path, &index_md);
                     }
@@ -45,8 +44,15 @@ impl Preprocessor for IndexPreprocessor {
 fn warn_readme_name_conflict<P: AsRef<Path>>(readme_path: P, index_path: P) {
     let file_name = readme_path.as_ref().file_name().unwrap_or_default();
     let parent_dir = index_path.as_ref().parent().unwrap_or(index_path.as_ref());
-    warn!("It seems that there are both {:?} and index.md under \"{}\".", file_name, parent_dir.display());
-    warn!("mdbook converts {:?} into index.html by default. It may cause", file_name);
+    warn!(
+        "It seems that there are both {:?} and index.md under \"{}\".",
+        file_name,
+        parent_dir.display()
+    );
+    warn!(
+        "mdbook converts {:?} into index.html by default. It may cause",
+        file_name
+    );
     warn!("unexpected behavior if putting both files under the same directory.");
     warn!("To solve the warning, try to rearrange the book structure or disable");
     warn!("\"index\" preprocessor to stop the conversion.");
@@ -60,7 +66,7 @@ fn is_readme_file<P: AsRef<Path>>(path: P) -> bool {
         path.as_ref()
             .file_stem()
             .and_then(|s| s.to_str())
-            .unwrap_or_default()
+            .unwrap_or_default(),
     )
 }
 

--- a/src/preprocess/mod.rs
+++ b/src/preprocess/mod.rs
@@ -1,10 +1,10 @@
 //! Book preprocessing.
 
-pub use self::links::LinkPreprocessor;
 pub use self::index::IndexPreprocessor;
+pub use self::links::LinkPreprocessor;
 
-mod links;
 mod index;
+mod links;
 
 use book::Book;
 use config::Config;

--- a/src/renderer/html_handlebars/hbs_renderer.rs
+++ b/src/renderer/html_handlebars/hbs_renderer.rs
@@ -132,8 +132,11 @@ impl HtmlHandlebars {
     ) -> Result<()> {
         use utils::fs::write_file;
 
-        write_file(destination, ".nojekyll", 
-            b"This file makes sure that Github Pages doesn't process mdBook's output.")?;
+        write_file(
+            destination,
+            ".nojekyll",
+            b"This file makes sure that Github Pages doesn't process mdBook's output.",
+        )?;
 
         write_file(destination, "book.js", &theme.js)?;
         write_file(destination, "book.css", &theme.css)?;
@@ -450,7 +453,10 @@ fn make_data(
     if cfg!(feature = "search") {
         let search = search.unwrap_or_default();
         data.insert("search_enabled".to_owned(), json!(search.enable));
-        data.insert("search_js".to_owned(), json!(search.enable && search.copy_js));
+        data.insert(
+            "search_js".to_owned(),
+            json!(search.enable && search.copy_js),
+        );
     } else if search.is_some() {
         warn!("mdBook compiled without search support, ignoring `output.html.search` table");
         warn!(
@@ -513,7 +519,7 @@ fn build_header_links(html: &str) -> String {
 fn wrap_header_with_link(
     level: usize,
     content: &str,
-    id_counter: &mut HashMap<String, usize>
+    id_counter: &mut HashMap<String, usize>,
 ) -> String {
     let raw_id = utils::id_from_content(content);
 
@@ -533,7 +539,6 @@ fn wrap_header_with_link(
         text = content
     )
 }
-
 
 // The rust book uses annotations for rustdoc to test code snippets,
 // like the following:
@@ -574,7 +579,8 @@ fn add_playpen_pre(html: &str, playpen_config: &Playpen) -> String {
             {
                 // wrap the contents in an external pre block
                 if playpen_config.editable && classes.contains("editable")
-                    || text.contains("fn main") || text.contains("quick_main!")
+                    || text.contains("fn main")
+                    || text.contains("quick_main!")
                 {
                     format!("<pre class=\"playpen\">{}</pre>", text)
                 } else {

--- a/src/renderer/html_handlebars/helpers/mod.rs
+++ b/src/renderer/html_handlebars/helpers/mod.rs
@@ -1,2 +1,2 @@
-pub mod toc;
 pub mod navigation;
+pub mod toc;

--- a/src/renderer/html_handlebars/helpers/navigation.rs
+++ b/src/renderer/html_handlebars/helpers/navigation.rs
@@ -1,8 +1,8 @@
-use std::path::Path;
 use std::collections::BTreeMap;
+use std::path::Path;
 
-use serde_json;
 use handlebars::{Context, Handlebars, Helper, RenderContext, RenderError, Renderable};
+use serde_json;
 
 use utils;
 
@@ -90,12 +90,14 @@ fn render(
 
     let mut context = BTreeMap::new();
     let base_path = rc.evaluate_absolute("path", false)?
-                      .as_str()
-                      .ok_or_else(|| RenderError::new("Type error for `path`, string expected"))?
-                      .replace("\"", "");
+        .as_str()
+        .ok_or_else(|| RenderError::new("Type error for `path`, string expected"))?
+        .replace("\"", "");
 
-    context.insert("path_to_root".to_owned(),
-                                json!(utils::fs::path_to_root(&base_path)));
+    context.insert(
+        "path_to_root".to_owned(),
+        json!(utils::fs::path_to_root(&base_path)),
+    );
 
     chapter
         .get("name")

--- a/src/renderer/html_handlebars/helpers/toc.rs
+++ b/src/renderer/html_handlebars/helpers/toc.rs
@@ -1,11 +1,11 @@
-use std::path::Path;
 use std::collections::BTreeMap;
+use std::path::Path;
 
 use utils;
 
-use serde_json;
 use handlebars::{Handlebars, Helper, HelperDef, RenderContext, RenderError};
 use pulldown_cmark::{html, Event, Parser, Tag};
+use serde_json;
 
 // Handlebars helper to construct TOC
 #[derive(Clone, Copy)]
@@ -79,7 +79,8 @@ impl HelperDef for RenderToc {
                         .replace("\\", "/");
 
                     // Add link
-                    rc.writer.write_all(&utils::fs::path_to_root(&current).as_bytes())?;
+                    rc.writer
+                        .write_all(&utils::fs::path_to_root(&current).as_bytes())?;
                     rc.writer.write_all(tmp.as_bytes())?;
                     rc.writer.write_all(b"\"")?;
 

--- a/src/renderer/html_handlebars/search.rs
+++ b/src/renderer/html_handlebars/search.rs
@@ -5,15 +5,15 @@ use std::borrow::Cow;
 use std::collections::{HashMap, HashSet};
 use std::path::Path;
 
+use self::elasticlunr::Index;
 use pulldown_cmark::*;
 use serde_json;
-use self::elasticlunr::Index;
 
 use book::{Book, BookItem};
 use config::Search;
 use errors::*;
-use utils;
 use theme::searcher;
+use utils;
 
 /// Creates all files required for search.
 pub fn create_files(search_config: &Search, destination: &Path, book: &Book) -> Result<()> {
@@ -32,7 +32,11 @@ pub fn create_files(search_config: &Search, destination: &Path, book: &Book) -> 
 
     if search_config.copy_js {
         utils::fs::write_file(destination, "searchindex.json", index.as_bytes())?;
-        utils::fs::write_file(destination, "searchindex.js", format!("window.search = {};", index).as_bytes())?;
+        utils::fs::write_file(
+            destination,
+            "searchindex.js",
+            format!("window.search = {};", index).as_bytes(),
+        )?;
         utils::fs::write_file(destination, "searcher.js", searcher::JS)?;
         utils::fs::write_file(destination, "mark.min.js", searcher::MARK_JS)?;
         utils::fs::write_file(destination, "elasticlunr.min.js", searcher::ELASTICLUNR_JS)?;
@@ -45,8 +49,8 @@ pub fn create_files(search_config: &Search, destination: &Path, book: &Book) -> 
 /// Uses the given arguments to construct a search document, then inserts it to the given index.
 fn add_doc(
     index: &mut Index,
-    doc_urls: &mut Vec<String>, 
-    anchor_base: &str, 
+    doc_urls: &mut Vec<String>,
+    anchor_base: &str,
     section_id: &Option<String>,
     items: &[&str],
 ) {
@@ -166,8 +170,8 @@ fn render_item(
 }
 
 fn write_to_json(index: Index, search_config: &Search, doc_urls: Vec<String>) -> Result<String> {
-    use std::collections::BTreeMap;
     use self::elasticlunr::config::{SearchBool, SearchOptions, SearchOptionsField};
+    use std::collections::BTreeMap;
 
     #[derive(Serialize)]
     struct ResultsOptions {

--- a/src/renderer/mod.rs
+++ b/src/renderer/mod.rs
@@ -15,16 +15,16 @@ pub use self::html_handlebars::HtmlHandlebars;
 
 mod html_handlebars;
 
+use serde_json;
+use shlex::Shlex;
 use std::fs;
 use std::io::{self, Read};
 use std::path::PathBuf;
 use std::process::{Command, Stdio};
-use serde_json;
-use shlex::Shlex;
 
-use errors::*;
-use config::Config;
 use book::Book;
+use config::Config;
+use errors::*;
 
 const MDBOOK_VERSION: &str = env!("CARGO_PKG_VERSION");
 
@@ -162,17 +162,21 @@ impl Renderer for CmdRenderer {
             .stdout(Stdio::inherit())
             .stderr(Stdio::inherit())
             .current_dir(&ctx.destination)
-            .spawn() {
-                Ok(c) => c,
-                Err(ref e) if e.kind() == io::ErrorKind::NotFound => {
-                    warn!("The command wasn't found, is the \"{}\" backend installed?", self.name);
-                    warn!("\tCommand: {}", self.cmd);
-                    return Ok(());
-                }
-                Err(e) => {
-                    return Err(e).chain_err(|| "Unable to start the backend")?;
-                }
-            };
+            .spawn()
+        {
+            Ok(c) => c,
+            Err(ref e) if e.kind() == io::ErrorKind::NotFound => {
+                warn!(
+                    "The command wasn't found, is the \"{}\" backend installed?",
+                    self.name
+                );
+                warn!("\tCommand: {}", self.cmd);
+                return Ok(());
+            }
+            Err(e) => {
+                return Err(e).chain_err(|| "Unable to start the backend")?;
+            }
+        };
 
         {
             let mut stdin = child.stdin.take().expect("Child has stdin");

--- a/src/theme/mod.rs
+++ b/src/theme/mod.rs
@@ -5,9 +5,9 @@ pub mod playpen_editor;
 #[cfg(feature = "search")]
 pub mod searcher;
 
-use std::path::Path;
 use std::fs::File;
 use std::io::Read;
+use std::path::Path;
 
 use errors::*;
 
@@ -33,7 +33,6 @@ pub static FONT_AWESOME_WOFF: &'static [u8] =
 pub static FONT_AWESOME_WOFF2: &'static [u8] =
     include_bytes!("FontAwesome/fonts/fontawesome-webfont.woff2");
 pub static FONT_AWESOME_OTF: &'static [u8] = include_bytes!("FontAwesome/fonts/FontAwesome.otf");
-
 
 /// The `Theme` struct should be used instead of the static variables because
 /// the `new()` method will look if the user has a theme directory in their
@@ -78,8 +77,14 @@ impl Theme {
                 (theme_dir.join("highlight.js"), &mut theme.highlight_js),
                 (theme_dir.join("clipboard.min.js"), &mut theme.clipboard_js),
                 (theme_dir.join("highlight.css"), &mut theme.highlight_css),
-                (theme_dir.join("tomorrow-night.css"), &mut theme.tomorrow_night_css),
-                (theme_dir.join("ayu-highlight.css"), &mut theme.ayu_highlight_css),
+                (
+                    theme_dir.join("tomorrow-night.css"),
+                    &mut theme.tomorrow_night_css,
+                ),
+                (
+                    theme_dir.join("ayu-highlight.css"),
+                    &mut theme.ayu_highlight_css,
+                ),
             ];
 
             for (filename, dest) in files {
@@ -130,12 +135,11 @@ fn load_file_contents<P: AsRef<Path>>(filename: P, dest: &mut Vec<u8>) -> Result
     Ok(())
 }
 
-
 #[cfg(test)]
 mod tests {
     use super::*;
-    use tempfile::Builder as TempFileBuilder;
     use std::path::PathBuf;
+    use tempfile::Builder as TempFileBuilder;
 
     #[test]
     fn theme_uses_defaults_with_nonexistent_src_dir() {

--- a/src/utils/fs.rs
+++ b/src/utils/fs.rs
@@ -25,16 +25,10 @@ pub fn normalize_path(path: &str) -> String {
 }
 
 /// Write the given data to a file, creating it first if necessary
-pub fn write_file<P: AsRef<Path>>(
-    build_dir: &Path,
-    filename: P,
-    content: &[u8],
-) -> Result<()> {
+pub fn write_file<P: AsRef<Path>>(build_dir: &Path, filename: P, content: &[u8]) -> Result<()> {
     let path = build_dir.join(filename);
 
-    create_file(&path)?
-        .write_all(content)
-        .map_err(|e| e.into())
+    create_file(&path)?.write_all(content).map_err(|e| e.into())
 }
 
 /// Takes a path and returns a path containing just enough `../` to point to

--- a/src/utils/string.rs
+++ b/src/utils/string.rs
@@ -1,5 +1,5 @@
-use std::ops::{Range, RangeFrom, RangeFull, RangeTo};
 use itertools::Itertools;
+use std::ops::{Range, RangeFrom, RangeFull, RangeTo};
 
 // This trait is already contained in the standard lib, however it is unstable.
 // TODO: Remove when the `collections_range` feature stabilises

--- a/tests/alternate_backends.rs
+++ b/tests/alternate_backends.rs
@@ -3,11 +3,11 @@
 extern crate mdbook;
 extern crate tempfile;
 
-#[cfg(not(windows))]
-use std::path::Path;
-use tempfile::{TempDir, Builder as TempFileBuilder};
 use mdbook::config::Config;
 use mdbook::MDBook;
+#[cfg(not(windows))]
+use std::path::Path;
+use tempfile::{Builder as TempFileBuilder, TempDir};
 
 #[test]
 fn passing_alternate_backend() {
@@ -52,8 +52,8 @@ fn tee_command<P: AsRef<Path>>(out_file: P) -> String {
 #[test]
 #[cfg(not(windows))]
 fn backends_receive_render_context_via_stdin() {
-    use std::fs::File;
     use mdbook::renderer::RenderContext;
+    use std::fs::File;
 
     let temp = TempFileBuilder::new().prefix("output").tempdir().unwrap();
     let out_file = temp.path().join("out.txt");

--- a/tests/dummy_book/mod.rs
+++ b/tests/dummy_book/mod.rs
@@ -7,18 +7,17 @@ extern crate mdbook;
 extern crate tempfile;
 extern crate walkdir;
 
-use std::path::Path;
-use std::fs::{self, File};
-use std::io::{Read, Write};
 use mdbook::errors::*;
 use mdbook::utils::fs::file_to_string;
+use std::fs::{self, File};
+use std::io::{Read, Write};
+use std::path::Path;
 
 // The funny `self::` here is because we've got an `extern crate ...` and are
 // in a submodule
-use self::tempfile::{TempDir, Builder as TempFileBuilder};
 use self::mdbook::MDBook;
+use self::tempfile::{Builder as TempFileBuilder, TempDir};
 use self::walkdir::WalkDir;
-
 
 /// Create a dummy book in a temporary directory, using the contents of
 /// `SUMMARY_MD` as a guide.
@@ -47,13 +46,16 @@ impl DummyBook {
 
     /// Write a book to a temporary directory using the provided settings.
     pub fn build(&self) -> Result<TempDir> {
-        let temp = TempFileBuilder::new().prefix("dummy_book").tempdir().chain_err(|| "Unable to create temp directory")?;
+        let temp = TempFileBuilder::new()
+            .prefix("dummy_book")
+            .tempdir()
+            .chain_err(|| "Unable to create temp directory")?;
 
         let dummy_book_root = Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/dummy_book");
         recursive_copy(&dummy_book_root, temp.path()).chain_err(|| {
-                                                                     "Couldn't copy files into a \
-                                                                      temporary directory"
-                                                                 })?;
+            "Couldn't copy files into a \
+             temporary directory"
+        })?;
 
         let sub_pattern = if self.passing_test { "true" } else { "false" };
         let file_containing_test = temp.path().join("src/first/nested.md");
@@ -77,11 +79,13 @@ pub fn assert_contains_strings<P: AsRef<Path>>(filename: P, strings: &[&str]) {
     let content = file_to_string(filename).expect("Couldn't read the file's contents");
 
     for s in strings {
-        assert!(content.contains(s),
-                "Searching for {:?} in {}\n\n{}",
-                s,
-                filename.display(),
-                content);
+        assert!(
+            content.contains(s),
+            "Searching for {:?} in {}\n\n{}",
+            s,
+            filename.display(),
+            content
+        );
     }
 }
 
@@ -90,14 +94,15 @@ pub fn assert_doesnt_contain_strings<P: AsRef<Path>>(filename: P, strings: &[&st
     let content = file_to_string(filename).expect("Couldn't read the file's contents");
 
     for s in strings {
-        assert!(!content.contains(s),
-                "Found {:?} in {}\n\n{}",
-                s,
-                filename.display(),
-                content);
+        assert!(
+            !content.contains(s),
+            "Found {:?} in {}\n\n{}",
+            s,
+            filename.display(),
+            content
+        );
     }
 }
-
 
 /// Recursively copy an entire directory tree to somewhere else (a la `cp -r`).
 fn recursive_copy<A: AsRef<Path>, B: AsRef<Path>>(from: A, to: B) -> Result<()> {
@@ -108,9 +113,9 @@ fn recursive_copy<A: AsRef<Path>, B: AsRef<Path>>(from: A, to: B) -> Result<()> 
         let entry = entry.chain_err(|| "Unable to inspect directory entry")?;
 
         let original_location = entry.path();
-        let relative = original_location.strip_prefix(&from)
-                                        .expect("`original_location` is inside the `from` \
-                                                 directory");
+        let relative = original_location
+            .strip_prefix(&from)
+            .expect("`original_location` is inside the `from` directory");
         let new_location = to.join(relative);
 
         if original_location.is_file() {
@@ -118,9 +123,8 @@ fn recursive_copy<A: AsRef<Path>, B: AsRef<Path>>(from: A, to: B) -> Result<()> 
                 fs::create_dir_all(parent).chain_err(|| "Couldn't create directory")?;
             }
 
-            fs::copy(&original_location, &new_location).chain_err(|| {
-                                                                      "Unable to copy file contents"
-                                                                  })?;
+            fs::copy(&original_location, &new_location)
+                .chain_err(|| "Unable to copy file contents")?;
         }
     }
 
@@ -129,7 +133,7 @@ fn recursive_copy<A: AsRef<Path>, B: AsRef<Path>>(from: A, to: B) -> Result<()> 
 
 pub fn new_copy_of_example_book() -> Result<TempDir> {
     let temp = TempFileBuilder::new().prefix("book-example").tempdir()?;
-    
+
     let book_example = Path::new(env!("CARGO_MANIFEST_DIR")).join("book-example");
 
     recursive_copy(book_example, temp.path())?;

--- a/tests/init.rs
+++ b/tests/init.rs
@@ -1,12 +1,11 @@
 extern crate mdbook;
 extern crate tempfile;
 
-use std::path::PathBuf;
-use std::fs;
-use mdbook::MDBook;
 use mdbook::config::Config;
+use mdbook::MDBook;
+use std::fs;
+use std::path::PathBuf;
 use tempfile::Builder as TempFileBuilder;
-
 
 /// Run `mdbook init` in an empty directory and make sure the default files
 /// are created.

--- a/tests/parse_existing_summary_files.rs
+++ b/tests/parse_existing_summary_files.rs
@@ -5,10 +5,10 @@ extern crate env_logger;
 extern crate error_chain;
 extern crate mdbook;
 
+use mdbook::book;
 use std::fs::File;
 use std::io::Read;
 use std::path::Path;
-use mdbook::book;
 
 macro_rules! summary_md_test {
     ($name:ident, $filename:expr) => {

--- a/tests/testing.rs
+++ b/tests/testing.rs
@@ -4,11 +4,11 @@ mod dummy_book;
 
 use dummy_book::DummyBook;
 
-use mdbook::MDBook;
-use mdbook::preprocess::{Preprocessor, PreprocessorContext};
 use mdbook::book::Book;
 use mdbook::config::Config;
 use mdbook::errors::*;
+use mdbook::preprocess::{Preprocessor, PreprocessorContext};
+use mdbook::MDBook;
 
 use std::sync::{Arc, Mutex};
 
@@ -30,7 +30,6 @@ fn mdbook_detects_book_with_failing_tests() {
 
 #[test]
 fn mdbook_runs_preprocessors() {
-
     let has_run: Arc<Mutex<bool>> = Arc::new(Mutex::new(false));
 
     struct DummyPreprocessor(Arc<Mutex<bool>>);


### PR DESCRIPTION
Removes `rustfmt.toml` as discussed in #688.