### PR TITLE
Support reproducible builds by forcing window.search to use stable key ordering.

### DIFF
--- a/src/renderer/html_handlebars/search.rs
+++ b/src/renderer/html_handlebars/search.rs
@@ -205,6 +205,10 @@ fn write_to_js(index: Index, search_config: &Search) -> Result<String> {
         searchoptions,
         index,
     };
+
+    // By converting to serde_json::Value as an intermediary, we use a
+    // BTreeMap internally and can force a stable ordering of map keys.
+    let json_contents = serde_json::to_value(&json_contents)?;
     let json_contents = serde_json::to_string(&json_contents)?;
 
     Ok(format!("window.search = {};", json_contents))


### PR DESCRIPTION
In CI, I run `mdbook build` to check that my repo's book is still well-formed. Each time I run this though, git notices that `searchindex.js` has been modified, even when I haven't made any changes to the book.

Running a diff on the old and new output shows that the only difference is in key ordering. Rust's HashMaps are randomly ordered, `elasticlunr-rs` uses HashMaps internally and when using `serde_json::to_string` that random order is directly written out.

We can force reproducible output by using `serde_json::Value` as an intermediary output, which uses BTreeMap internally, and will order the output keys consistently when written to a JSON string.

I can confirm that rerunning `mdbook build` repeatedly in my repo does not cause `searchindex.js` to be marked as modified.