### PR TITLE
Fix default theme dir selection

### DIFF
--- a/src/renderer/html_handlebars/hbs_renderer.rs
+++ b/src/renderer/html_handlebars/hbs_renderer.rs
@@ -273,7 +273,7 @@ impl Renderer for HtmlHandlebars {
 
         let theme_dir = match html_config.theme {
             Some(ref theme) => theme.to_path_buf(),
-            None => src_dir.join("theme"),
+            None => ctx.root.join("theme"),
         };
 
         let theme = theme::Theme::new(theme_dir);

--- a/src/renderer/html_handlebars/hbs_renderer.rs
+++ b/src/renderer/html_handlebars/hbs_renderer.rs
@@ -257,6 +257,24 @@ impl HtmlHandlebars {
     }
 }
 
+// TODO(mattico): Remove some time after the 0.1.8 release
+fn maybe_wrong_theme_dir(dir: &Path) -> Result<bool> {
+    fn entry_is_maybe_book_file(entry: fs::DirEntry) -> Result<bool> {
+        Ok(entry.file_type()?.is_file() && entry.path().extension().map_or(false, |ext| ext == "md"))
+    }
+
+    if dir.is_dir() {
+        for entry in fs::read_dir(dir)? {
+            if entry_is_maybe_book_file(entry?).unwrap_or(false) {
+                return Ok(false);
+            }
+        }
+        Ok(true)
+    } else {
+        Ok(false)
+    }
+}
+
 impl Renderer for HtmlHandlebars {
     fn name(&self) -> &str {
         "html"
@@ -275,6 +293,11 @@ impl Renderer for HtmlHandlebars {
             Some(ref theme) => theme.to_path_buf(),
             None => ctx.root.join("theme"),
         };
+
+        if html_config.theme.is_none() && maybe_wrong_theme_dir(&src_dir.join("theme")).unwrap_or(false) {
+            warn!("Previous versions of mdBook erroneously accepted `./src/theme` as an automatic theme directory");
+            warn!("Please move your theme files to `./theme` for them to continue being used");
+        }
 
         let theme = theme::Theme::new(theme_dir);
 


### PR DESCRIPTION
Fixes #695 

Another option would be to accept both `/theme` and `/src/theme`, since some may have begun relying on the undocumented behavior.