### PR TITLE
Allow sidebar section titles to wrap

### DIFF
--- a/src/theme/book.css
+++ b/src/theme/book.css
@@ -132,12 +132,6 @@ table thead td {
   padding-left: 20px;
   line-height: 1.9em;
 }
-.section li {
-  -o-text-overflow: ellipsis;
-  text-overflow: ellipsis;
-  overflow: hidden;
-  white-space: nowrap;
-}
 .page-wrapper {
   -webkit-box-sizing: border-box;
   -moz-box-sizing: border-box;

--- a/src/theme/stylus/sidebar.styl
+++ b/src/theme/stylus/sidebar.styl
@@ -53,10 +53,4 @@
     list-style: none outside none
     padding-left: 20px
     line-height: 1.9em
-
-    li {
-        text-overflow: ellipsis
-        overflow: hidden
-        white-space: nowrap
-    }
 }


### PR DESCRIPTION
Fixes #729.

The original intent was to have ellipsis on long titles, but I don't think that works well for subsections given the narrow width of our sidebar. Allowing titles to wrap doesn't look too bad:

![image](https://user-images.githubusercontent.com/853158/43154355-b2bbd6d0-8f39-11e8-88e8-3f2f8c73bb86.png)
