### PR TITLE
Adjust header icon margins

### DIFF
--- a/src/theme/book.css
+++ b/src/theme/book.css
@@ -224,6 +224,12 @@ table thead td {
   -ms-transition: color 0.5s;
   transition: color 0.5s;
 }
+@media only screen and (max-width: 420px) {
+  #menu-bar i,
+  #menu-bar .icon-button {
+    margin: 0 5px;
+  }
+}
 #menu-bar #print-button {
   margin: 0 15px;
 }

--- a/src/theme/stylus/menu.styl
+++ b/src/theme/stylus/menu.styl
@@ -15,6 +15,9 @@
     i, .icon-button {
         position: relative
         margin: 0 10px
+        @media only screen and (max-width: $narrow-device-max-width) {
+            margin: 0 5px
+        }
         z-index: 10
         line-height: 50px
         cursor: pointer

--- a/src/theme/stylus/variables.styl
+++ b/src/theme/stylus/variables.styl
@@ -4,3 +4,4 @@ $content-max-width = 750px
 $content-min-width = 320px
 $page-plus-sidebar-width = $content-max-width + $sidebar-width + $page-padding * 2
 $sidebar-reflow-width = $sidebar-width + $content-min-width
+$narrow-device-max-width = 420px


### PR DESCRIPTION
Before:

![image](https://user-images.githubusercontent.com/853158/43155759-e3fe6826-8f3d-11e8-9bdb-bca23afb0975.png)

![image](https://user-images.githubusercontent.com/853158/43155814-0efbaac0-8f3e-11e8-84d4-73e2e21eea05.png)

After:

![image](https://user-images.githubusercontent.com/853158/43155698-b50279d6-8f3d-11e8-99e2-bf9354bde5c6.png)

![image](https://user-images.githubusercontent.com/853158/43155733-cb0fbb12-8f3d-11e8-862c-10def7513c7b.png)

I think an ideal solution would move these controls into the sidebar for very narrow devices, but this at least shows a few more characters of the title and allows the sidebar to be closed (barely).
