### PR TITLE
Reduce the margins on header icons on narrow devices

### DIFF
--- a/src/theme/book.css
+++ b/src/theme/book.css
@@ -217,7 +217,7 @@ table thead td {
 #menu-bar i,
 #menu-bar .icon-button {
   position: relative;
-  margin: 0 10px;
+  margin: 0 8px;
   z-index: 10;
   line-height: 50px;
   cursor: pointer;
@@ -226,6 +226,12 @@ table thead td {
   -o-transition: color 0.5s;
   -ms-transition: color 0.5s;
   transition: color 0.5s;
+}
+@media only screen and (max-width: 420px) {
+  #menu-bar i,
+  #menu-bar .icon-button {
+    margin: 0 5px;
+  }
 }
 #menu-bar #print-button {
   margin: 0 15px;
@@ -236,6 +242,9 @@ html:not(.sidebar-visible) #menu-bar:not(:hover).folded > #menu-bar-sticky-conta
   -o-transform: translateY(-60px);
   -ms-transform: translateY(-60px);
   transform: translateY(-60px);
+}
+.left-buttons {
+  margin: 0 5px;
 }
 .no-js .left-buttons {
   display: none;

--- a/src/theme/stylus/menu.styl
+++ b/src/theme/stylus/menu.styl
@@ -14,7 +14,10 @@
 
     i, .icon-button {
         position: relative
-        margin: 0 10px
+        margin: 0 8px
+        @media only screen and (max-width: $narrow-device-max-width) {
+            margin: 0 5px
+        }
         z-index: 10
         line-height: 50px
         cursor: pointer
@@ -30,8 +33,9 @@ html:not(.sidebar-visible) #menu-bar:not(:hover).folded > #menu-bar-sticky-conta
     transform: translateY(-60px);
 }
 
-.no-js .left-buttons {
-    display: none
+.left-buttons {
+    .no-js & { display: none }
+    margin: 0 5px
 }
 
 .menu-title {

--- a/src/theme/stylus/variables.styl
+++ b/src/theme/stylus/variables.styl
@@ -4,3 +4,4 @@ $content-max-width = 750px
 $content-min-width = 320px
 $page-plus-sidebar-width = $content-max-width + $sidebar-width + $page-padding * 2
 $sidebar-reflow-width = $sidebar-width + $content-min-width
+$narrow-device-max-width = 420px


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/853158/43220159-f70cafdc-900e-11e8-94ae-79f93711ebd9.png)
![image](https://user-images.githubusercontent.com/853158/43220186-100a6b1e-900f-11e8-9f5a-529984d9e9ae.png)

After:
![image](https://user-images.githubusercontent.com/853158/43220136-e6a3f6dc-900e-11e8-904a-681d3761e44f.png)
![image](https://user-images.githubusercontent.com/853158/43220227-293fac2a-900f-11e8-9a4e-96385c4b4773.png)

I think an ideal solution would move these controls into the sidebar on narrow viewports, but this is an easy improvement for now.