### PR TITLE
Add a "noplaypen" class for rust code samples.

### DIFF
--- a/src/renderer/html_handlebars/hbs_renderer.rs
+++ b/src/renderer/html_handlebars/hbs_renderer.rs
@@ -580,7 +580,9 @@ fn add_playpen_pre(html: &str, playpen_config: &Playpen) -> String {
             let classes = &caps[2];
             let code = &caps[3];
 
-            if (classes.contains("language-rust") && !classes.contains("ignore"))
+            if (classes.contains("language-rust")
+                && !classes.contains("ignore")
+                && !classes.contains("noplaypen"))
                 || classes.contains("mdbook-runnable")
             {
                 // wrap the contents in an external pre block


### PR DESCRIPTION
This class will supress the "play" button in the html backend (which you can also do with the "ignore" class), but it will still let the code be tested via `mdbook test` (which is not possible with the "ignore" class).

This is useful for code examples that don't really do much (and so the user doesn't gain much from running them), but as an author you still want to test them to guard against syntax errors and typos and the like.

Notes:  this new class is not documented (see #602), and also this uses the term "playpen", which is prevalent in the mdbook source code, but is not the preferred name (see #674)