### PR TITLE
Improve command-line argument parsing

### DIFF
--- a/book-example/src/cli/build.md
+++ b/book-example/src/cli/build.md
@@ -14,8 +14,8 @@ convenience. Large books will therefore remain structured when rendered.
 
 #### Specify a directory
 
-Like `init`, the `build` command can take a directory as an argument to use
-instead of the current working directory.
+The `build` command can take a directory as an argument to use as the book's
+root instead of the current working directory.
 
 ```bash
 mdbook build path/to/book
@@ -23,13 +23,16 @@ mdbook build path/to/book
 
 #### --open
 
-When you use the `--open` (`-o`) option, mdbook will open the rendered book in
+When you use the `--open` (`-o`) flag, mdbook will open the rendered book in
 your default web browser after building it.
 
 #### --dest-dir
 
-The `--dest-dir` (`-d`) option allows you to change the output directory for your book.
+The `--dest-dir` (`-d`) option allows you to change the output directory for
+the book. If not specified it will default to the value of the
+`build.build-dir` key in `book.toml`, or to `./book` relative to the book's
+root directory.
 
 -------------------
 
-***note:*** *make sure to run the build command in the root directory and not in the source directory*
+***Note:*** *Make sure to run the build command in the root directory and not in the source directory*

--- a/book-example/src/cli/clean.md
+++ b/book-example/src/cli/clean.md
@@ -7,12 +7,21 @@ artifacts.
 mdbook clean
 ```
 
-It will try to delete the built book. If a path is provided, it will be used.
-
 #### Specify a directory
 
-Like `init`, the `clean` command can take a directory as an argument to use
-instead of the normal build directory.
+The `clean` command can take a directory as an argument to use as the book's
+root instead of the current working directory.
+
+```bash
+mdbook clean path/to/book
+```
+
+#### --dest-dir
+
+The `--dest-dir` (`-d`) option allows you to override the book's output
+directory, which will be deleted by this command. If not specified it
+will default to the value of the `build.build-dir` key in `book.toml`, or to
+`./book` relative to the book's root directory.
 
 ```bash
 mdbook clean --dest-dir=path/to/book

--- a/book-example/src/cli/init.md
+++ b/book-example/src/cli/init.md
@@ -1,5 +1,7 @@
 # The init command
-There is some minimal boilerplate that is the same for every new book. It's for this purpose that mdBook includes an `init` command.
+
+There is some minimal boilerplate that is the same for every new book. It's for this purpose
+that mdBook includes an `init` command.
 
 The `init` command is used like this:
 
@@ -22,23 +24,27 @@ configuration files, etc.
 - The `book` directory is where your book is rendered. All the output is ready to be uploaded
 to a server to be seen by your audience.
 
-- The `SUMMARY.md` file is the most important file, it's the skeleton of your book and is discussed in more detail in another  [chapter](../format/summary.md)
+- The `SUMMARY.md` file is the most important file, it's the skeleton of your book and is
+discussed in more detail [in another chapter](../format/summary.md)
 
-#### Tip & Trick: Hidden Feature
-When a `SUMMARY.md` file already exists, the `init` command will first parse it and generate the missing files according to the paths used in the `SUMMARY.md`. This allows you to think and create the whole structure of your book and then let mdBook generate it for you.
+#### Tip: Generate chapters from SUMMARY.md
+
+When a `SUMMARY.md` file already exists, the `init` command will first parse it and generate the
+missing files according to the paths used in the `SUMMARY.md`. This allows you to think and create
+the whole structure of your book and then let mdBook generate it for you.
 
 #### Specify a directory
 
-When using the `init` command, you can also specify a directory, instead of using the current working directory,
-by appending a path to the command:
+The `init` command can take a directory as an argument to use as the book's
+root instead of the current working directory.
 
 ```bash
 mdbook init path/to/book
 ```
 
-## --theme
+#### --theme
 
-When you use the `--theme` argument, the default theme will be copied into a directory
+When you use the `--theme` flag, the default theme will be copied into a directory
 called `theme` in your source directory so that you can modify it.
 
 The theme is selectively overwritten, this means that if you don't want to overwrite a

--- a/book-example/src/cli/serve.md
+++ b/book-example/src/cli/serve.md
@@ -1,40 +1,50 @@
 # The serve command
 
-The `serve` command is useful when you want to preview your book. It also does hot reloading of the webpage whenever a file changes.
-It achieves this by serving the books content over `localhost:3000` (unless otherwise configured, see below) and runs a websocket server on `localhost:3001` which triggers the reloads.
-This preferred by many for writing books with mdbook because it allows for you to see the result of your work instantly after every file change.
+The serve command is used to preview a book by serving it over HTTP at
+`localhost:3000` by default. Additionally it watches the book's directory
+for changes, rebuilding the book and refreshing clients for each change.
+A websocket connection is used to trigger the client-side refresh.
 
 #### Specify a directory
 
-Like `watch`, `serve` can take a directory as an argument to use instead of
-the current working directory.
+The `serve` command can take a directory as an argument to use as the book's
+root instead of the current working directory.
 
 ```bash
 mdbook serve path/to/book
 ```
 
-
 #### Server options
 
-`serve` has four options: the http port, the websocket port, the interface to serve on, and the public address of the server so that the browser may reach the websocket server.
+`serve` has four options: the HTTP port, the WebSocket port, the HTTP hostname
+to listen on, and the hostname for the browser to connect to for WebSockets.
 
-For example: suppose you had an nginx server for SSL termination which has a public address of 192.168.1.100 on port 80 and proxied that to 127.0.0.1 on port 8000. To run use the nginx proxy do:
+For example: suppose you have an nginx server for SSL termination which has a
+public address of 192.168.1.100 on port 80 and proxied that to 127.0.0.1 on
+port 8000. To run use the nginx proxy do:
 
 ```bash
-mdbook serve path/to/book -p 8000 -i 127.0.0.1 -a 192.168.1.100
+mdbook serve path/to/book -p 8000 -n 127.0.0.1 --websocket-hostname 192.168.1.100
 ```
 
-If you were to want live reloading for this you would need to proxy the websocket calls through nginx as well from `192.168.1.100:<WS_PORT>` to `127.0.0.1:<WS_PORT>`. The `-w` flag allows for the websocket port to be configured.
+If you were to want live reloading for this you would need to proxy the
+websocket calls through nginx as well from `192.168.1.100:<WS_PORT>` to
+`127.0.0.1:<WS_PORT>`. The `-w` flag allows for the websocket port to be
+configured.
 
 #### --open
 
-When you use the `--open` (`-o`) option, mdbook will open the book in your
+When you use the `--open` (`-o`) flag, mdbook will open the book in your
 your default web browser after starting the server.
 
 #### --dest-dir
 
-The `--dest-dir` (`-d`) option allows you to change the output directory for your book.
+The `--dest-dir` (`-d`) option allows you to change the output directory for
+the book. If not specified it will default to the value of the
+`build.build-dir` key in `book.toml`, or to `./book` relative to the book's
+root directory.
 
 -----
 
-***note:*** *the `serve` command has not gotten a lot of testing yet, there could be some rough edges. If you discover a problem, please report it [on Github](https://github.com/rust-lang-nursery/mdBook/issues)*
+***Note:*** *The `serve` command is for testing, and is not intended
+to be a complete HTTP server for a website.*

--- a/book-example/src/cli/test.md
+++ b/book-example/src/cli/test.md
@@ -1,19 +1,53 @@
 # The test command
 
-When writing a book, you sometimes need to automate some tests. For example, [The Rust Programming Book](https://doc.rust-lang.org/stable/book/) uses a lot of code examples that could get outdated.
-Therefore it is very important for them to be able to automatically test these code examples.
+When writing a book, you sometimes need to automate some tests. For example,
+[The Rust Programming Book](https://doc.rust-lang.org/stable/book/) uses a lot
+of code examples that could get outdated. Therefore it is very important for
+them to be able to automatically test these code examples.
 
-mdBook supports a `test` command that will run all available tests in mdBook. At the moment, only one test is available:
-*"Test Rust code examples using Rustdoc"*, but I hope this will be expanded in the future to include more tests like:
+mdBook supports a `test` command that will run all available tests in a book.
+At the moment, only rustdoc tests are supported, but this may be expanded upon
+in the future.
 
-- checking for broken links
-- checking for unused files
-- ...
+#### Disable tests on a code block
 
-In the future I would like the user to be able to enable / disable test from the `book.toml` configuration file and support custom tests.
+rustdoc doesn't test code blocks which contain the `ignore` attribute:
 
-**How to use it:**
+    ```rust,ignore
+    fn main() {}
+    ```
+
+rustdoc also doesn't test code blocks which specify a language other than Rust:
+
+    ```markdown
+    **Foo**: _bar_
+    ```
+
+rustdoc *does* test code blocks which have no language specified:
+
+    ```
+    This is going to cause an error!
+    ```
+
+#### Specify a directory
+
+The `test` command can take a directory as an argument to use as the book's
+root instead of the current working directory.
+
 ```bash
-$ mdbook test
-[*]: Testing file: "/mdBook/book-example/src/README.md”
+mdbook test path/to/book
 ```
+
+#### --library-path
+
+The `--library-path` (`-L`) option allows you to add directories to the library
+search path used by `rustdoc` when it builds and tests the examples. Multiple
+directories can be specified with multiple options (`-L foo -L bar`) or with a
+comma-delimited list (`-L foo,bar`).
+
+#### --dest-dir
+
+The `--dest-dir` (`-d`) option allows you to change the output directory for
+the book. If not specified it will default to the value of the
+`build.build-dir` key in `book.toml`, or to `./book` relative to the book's
+root directory.

--- a/book-example/src/cli/watch.md
+++ b/book-example/src/cli/watch.md
@@ -1,12 +1,14 @@
 # The watch command
 
-The `watch` command is useful when you want your book to be rendered on every file change.
-You could repeatedly issue `mdbook build` every time a file is changed. But using `mdbook watch` once will watch your files and will trigger a build automatically whenever you modify a file.
+The `watch` command is useful when you want your book to be rendered on every
+file change. You could repeatedly issue `mdbook build` every time a file is
+changed. But using `mdbook watch` once will watch your files and will trigger
+a build automatically whenever you modify a file.
 
 #### Specify a directory
 
-Like `init` and `build`, `watch` can take a directory as an argument to use
-instead of the current working directory.
+The `watch` command can take a directory as an argument to use as the book's
+root instead of the current working directory.
 
 ```bash
 mdbook watch path/to/book
@@ -19,8 +21,7 @@ your default web browser.
 
 #### --dest-dir
 
-The `--dest-dir` (`-d`) option allows you to change the output directory for your book.
-
------
-
-***note:*** *the `watch` command has not gotten a lot of testing yet, there could be some rough edges. If you discover a problem, please report it [on Github](https://github.com/rust-lang-nursery/mdBook/issues)*
+The `--dest-dir` (`-d`) option allows you to change the output directory for
+the book. If not specified it will default to the value of the
+`build.build-dir` key in `book.toml`, or to `./book` relative to the book's
+root directory.

--- a/book-example/src/format/mdbook.md
+++ b/book-example/src/format/mdbook.md
@@ -29,7 +29,7 @@ Will render as
 With the following syntax, you can include files into your book:
 
 ```hbs
-\{{#include file.rs}}
+{{#include file.rs}}
 ```
 
 The path to the file has to be relative from the current source file.
@@ -37,10 +37,10 @@ The path to the file has to be relative from the current source file.
 Usually, this command is used for including code snippets and examples. In this case, oftens one would include a specific part of the file e.g. which only contains the relevant lines for the example. We support four different modes of partial includes:
 
 ```hbs
-\{{#include file.rs:2}}
-\{{#include file.rs::10}}
-\{{#include file.rs:2:}}
-\{{#include file.rs:2:10}}
+{{#include file.rs:2}}
+{{#include file.rs::10}}
+{{#include file.rs:2:}}
+{{#include file.rs:2:10}}
 ```
 
 The first command only includes the second line from file `file.rs`. The second command includes all lines up to line 10, i.e. the lines from 11 till the end of the file are omitted. The third command includes all lines from line 2, i.e. the first line is omitted. The last command includes the excerpt of `file.rs` consisting of lines 2 to 10.
@@ -50,7 +50,7 @@ The first command only includes the second line from file `file.rs`. The second 
 With the following syntax, you can insert runnable Rust files into your book:
 
 ```hbs
-\{{#playpen file.rs}}
+{{#playpen file.rs}}
 ```
 
 The path to the Rust file has to be relative from the current source file.

--- a/book-example/src/format/theme/index-hbs.md
+++ b/book-example/src/format/theme/index-hbs.md
@@ -37,7 +37,7 @@ Since the original directory structure is maintained, it is useful to prepend re
 
 In addition to the properties you can access, there are some handlebars helpers at your disposal.
 
-1.  ### toc
+### 1. toc
 
     The toc helper is used like this
 
@@ -68,7 +68,7 @@ In addition to the properties you can access, there are some handlebars helpers 
     </script>
     ```
 
-2.  ### previous / next
+### 2. previous / next
 
     The previous and next helpers expose a `link` and `name` property to the previous and next chapters.
 
@@ -87,5 +87,4 @@ In addition to the properties you can access, there are some handlebars helpers 
 
 ------
 
-*If you would like me to expose other properties or helpers, please [create a new issue](https://github.com/rust-lang-nursery/mdBook/issues)
-and I will consider it.*
+*If you would like other properties or helpers exposed, please [create a new issue](https://github.com/rust-lang-nursery/mdBook/issues)*

--- a/src/cmd/build.rs
+++ b/src/cmd/build.rs
@@ -1,21 +1,21 @@
 use clap::{App, ArgMatches, SubCommand};
 use mdbook::errors::Result;
 use mdbook::MDBook;
-use std::path::PathBuf;
 use {get_book_dir, open};
 
 // Create clap subcommand arguments
 pub fn make_subcommand<'a, 'b>() -> App<'a, 'b> {
     SubCommand::with_name("build")
-        .about("Build the book from the markdown files")
-        .arg_from_usage("-o, --open 'Open the compiled book in a web browser'")
+        .about("Builds a book from its markdown files")
         .arg_from_usage(
-            "-d, --dest-dir=[dest-dir] 'The output directory for your book{n}(Defaults to ./book \
-             when omitted)'",
+            "-d, --dest-dir=[dest-dir] 'Output directory for the book{n}\
+             (If omitted, uses build.build-dir from book.toml or defaults to ./book)'",
         )
         .arg_from_usage(
-            "[dir] 'A directory for your book{n}(Defaults to Current Directory when omitted)'",
+            "[dir] 'Root directory for the book{n}\
+             (Defaults to the Current Directory when omitted)'",
         )
+        .arg_from_usage("-o, --open 'Opens the compiled book in a web browser'")
 }
 
 // Build command implementation
@@ -24,7 +24,7 @@ pub fn execute(args: &ArgMatches) -> Result<()> {
     let mut book = MDBook::load(&book_dir)?;
 
     if let Some(dest_dir) = args.value_of("dest-dir") {
-        book.config.build.build_dir = PathBuf::from(dest_dir);
+        book.config.build.build_dir = dest_dir.into();
     }
 
     book.build()?;

--- a/src/cmd/clean.rs
+++ b/src/cmd/clean.rs
@@ -3,15 +3,18 @@ use get_book_dir;
 use mdbook::errors::*;
 use mdbook::MDBook;
 use std::fs;
-use std::path::PathBuf;
 
 // Create clap subcommand arguments
 pub fn make_subcommand<'a, 'b>() -> App<'a, 'b> {
     SubCommand::with_name("clean")
-        .about("Delete built book")
+        .about("Deletes a built book")
         .arg_from_usage(
-            "-d, --dest-dir=[dest-dir] 'The directory of built book{n}(Defaults to ./book when \
-             omitted)'",
+            "-d, --dest-dir=[dest-dir] 'Output directory for the book{n}\
+             (If omitted, uses build.build-dir from book.toml or defaults to ./book)'",
+        )
+        .arg_from_usage(
+            "[dir] 'Root directory for the book{n}\
+             (Defaults to the Current Directory when omitted)'",
         )
 }
 
@@ -21,7 +24,7 @@ pub fn execute(args: &ArgMatches) -> ::mdbook::errors::Result<()> {
     let book = MDBook::load(&book_dir)?;
 
     let dir_to_remove = match args.value_of("dest-dir") {
-        Some(dest_dir) => PathBuf::from(dest_dir),
+        Some(dest_dir) => dest_dir.into(),
         None => book.root.join(&book.config.build.build_dir),
     };
     fs::remove_dir_all(&dir_to_remove).chain_err(|| "Unable to remove the build directory")?;

--- a/src/cmd/init.rs
+++ b/src/cmd/init.rs
@@ -10,12 +10,12 @@ use std::process::Command;
 // Create clap subcommand arguments
 pub fn make_subcommand<'a, 'b>() -> App<'a, 'b> {
     SubCommand::with_name("init")
-        .about("Create boilerplate structure and files in the directory")
+        .about("Creates the boilerplate structure and files for a new book")
         // the {n} denotes a newline which will properly aligned in all help messages
-        .arg_from_usage("[dir] 'A directory for your book{n}(Defaults to Current Directory \
-                         when omitted)'")
+        .arg_from_usage("[dir] 'Directory to create the book in{n}\
+            (Defaults to the Current Directory when omitted)'")
         .arg_from_usage("--theme 'Copies the default theme into your source folder'")
-        .arg_from_usage("--force 'skip confirmation prompts'")
+        .arg_from_usage("--force 'Skips confirmation prompts'")
 }
 
 // Init command implementation

--- a/src/cmd/watch.rs
+++ b/src/cmd/watch.rs
@@ -13,11 +13,16 @@ use {get_book_dir, open};
 // Create clap subcommand arguments
 pub fn make_subcommand<'a, 'b>() -> App<'a, 'b> {
     SubCommand::with_name("watch")
-        .about("Watch the files for changes")
-        .arg_from_usage("-o, --open 'Open the compiled book in a web browser'")
+        .about("Watches a book's files and rebuilds it on changes")
         .arg_from_usage(
-            "[dir] 'A directory for your book{n}(Defaults to Current Directory when omitted)'",
+            "-d, --dest-dir=[dest-dir] 'Output directory for the book{n}\
+             (If omitted, uses build.build-dir from book.toml or defaults to ./book)'",
         )
+        .arg_from_usage(
+            "[dir] 'Root directory for the book{n}\
+             (Defaults to the Current Directory when omitted)'",
+        )
+        .arg_from_usage("-o, --open 'Open the compiled book in a web browser'")
 }
 
 // Watch command implementation

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,26 +20,27 @@ use std::path::{Path, PathBuf};
 
 mod cmd;
 
-const NAME: &'static str = "mdbook";
+const NAME: &'static str = "mdBook";
+const VERSION: &'static str = concat!("v", crate_version!());
 
 fn main() {
     init_logger();
 
     // Create a list of valid arguments and sub-commands
     let app = App::new(NAME)
-                .about("Create a book in form of a static website from markdown files")
-                .author("Mathieu David <mathieudavid@mathieudavid.org>")
-                // Get the version from our Cargo.toml using clap's crate_version!() macro
-                .version(concat!("v",crate_version!()))
-                .setting(AppSettings::ArgRequiredElseHelp)
-                .after_help("For more information about a specific command, \
-                             try `mdbook <command> --help`\n\
-                             Source code for mdbook available \
-                             at: https://github.com/rust-lang-nursery/mdBook")
-                .subcommand(cmd::init::make_subcommand())
-                .subcommand(cmd::build::make_subcommand())
-                .subcommand(cmd::test::make_subcommand())
-                .subcommand(cmd::clean::make_subcommand());
+        .about("Creates a book from markdown files")
+        .author("Mathieu David <mathieudavid@mathieudavid.org>")
+        .version(VERSION)
+        .setting(AppSettings::GlobalVersion)
+        .setting(AppSettings::ArgRequiredElseHelp)
+        .after_help(
+            "For more information about a specific command, try `mdbook <command> --help`\n\
+             The source code for mdBook is available at: https://github.com/rust-lang-nursery/mdBook",
+        )
+        .subcommand(cmd::init::make_subcommand())
+        .subcommand(cmd::build::make_subcommand())
+        .subcommand(cmd::test::make_subcommand())
+        .subcommand(cmd::clean::make_subcommand());
 
     #[cfg(feature = "watch")]
     let app = app.subcommand(cmd::watch::make_subcommand());


### PR DESCRIPTION
Mostly improves wording and formatting. Includes breaking changes to two subcommands:
- **serve**: some arguments have been renamed to make more sense
- **test**: the `library-path` argument now requires a comma-delimiter so that ` -- ` isn't required to give a `dir` argument