### PR TITLE
Allow non alphabetic initial in heading anchor

### DIFF
--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -329,12 +329,32 @@ more text with spaces
         #[test]
         fn it_generates_anchors() {
             assert_eq!(
-                id_from_content("## `--passes`: add more rustdoc passes"),
-                "a--passes-add-more-rustdoc-passes"
-            );
-            assert_eq!(
                 id_from_content("## Method-call expressions"),
                 "method-call-expressions"
+            );
+            assert_eq!(
+                id_from_content("## **Bold** title"),
+                "bold-title"
+            );
+            assert_eq!(
+                id_from_content("## `Code` title"),
+                "code-title"
+            );
+        }
+
+        #[test]
+        fn it_generates_anchors_from_non_ascii_initial() {
+            assert_eq!(
+                id_from_content("## `--passes`: add more rustdoc passes"),
+                "--passes-add-more-rustdoc-passes"
+            );
+            assert_eq!(
+                id_from_content("## 中文標題 CJK title"),
+                "中文標題-cjk-title"
+            );
+            assert_eq!(
+                id_from_content("## Über"),
+                "Über"
             );
         }
 
@@ -342,14 +362,17 @@ more text with spaces
         fn it_normalizes_ids() {
             assert_eq!(
                 normalize_id("`--passes`: add more rustdoc passes"),
-                "a--passes-add-more-rustdoc-passes"
+                "--passes-add-more-rustdoc-passes"
             );
             assert_eq!(
                 normalize_id("Method-call 🐙 expressions \u{1f47c}"),
                 "method-call--expressions-"
             );
-            assert_eq!(normalize_id("_-_12345"), "a_-_12345");
-            assert_eq!(normalize_id("12345"), "a12345");
+            assert_eq!(normalize_id("_-_12345"), "_-_12345");
+            assert_eq!(normalize_id("12345"), "12345");
+            assert_eq!(normalize_id("中文"), "中文");
+            assert_eq!(normalize_id("にほんご"), "にほんご");
+            assert_eq!(normalize_id("한국어"), "한국어");
             assert_eq!(normalize_id(""), "");
         }
     }

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -21,9 +21,10 @@ pub fn collapse_whitespace<'a>(text: &'a str) -> Cow<'a, str> {
     RE.replace_all(text, " ")
 }
 
-/// Convert the given string to a valid HTML element ID
+/// Convert the given string to a valid HTML element ID.
+/// The only restriction is that the ID must not contain any ASCII whitespace.
 pub fn normalize_id(content: &str) -> String {
-    let mut ret = content
+    content
         .chars()
         .filter_map(|ch| {
             if ch.is_alphanumeric() || ch == '_' || ch == '-' {
@@ -33,16 +34,7 @@ pub fn normalize_id(content: &str) -> String {
             } else {
                 None
             }
-        }).collect::<String>();
-    // Ensure that the first character is [A-Za-z]
-    if ret
-        .chars()
-        .next()
-        .map_or(false, |c| !c.is_ascii_alphabetic())
-    {
-        ret.insert(0, 'a');
-    }
-    ret
+        }).collect::<String>()
 }
 
 /// Generate an ID for use with anchors which is derived from a "normalised"


### PR DESCRIPTION
In HTML5 standard, there is no restriction on what forms an ID attribute. The only reason to append a alphabet in the front of original characters is for compatibility. 

As far as I know, some popular content generating services, including GitHub, GitBook and GitLab, accept a heading with non-alphabetic initial as a valid ID attribute. Maybe we can conform with the standards without appending an unexpected arbitrary character on ID. This feature will make writing much more ergonomic for non-English users.

Reference: https://www.w3.org/TR/html52/dom.html#element-attrdef-global-id