### PR TITLE
Fix broken link to API pages

### DIFF
--- a/book-example/src/for_developers/README.md
+++ b/book-example/src/for_developers/README.md
@@ -42,5 +42,5 @@ explanation on the configuration system.
 
 
 [`MDBook`]: http://rust-lang-nursery.github.io/mdBook/mdbook/book/struct.MDBook.html
-[API Docs]: http://rust-lang-nursery.github.io/mdBook/mdbook/
+[API Docs]: https://docs.rs/mdbook/*/mdbook/
 [config]: file:///home/michael/Documents/forks/mdBook/target/doc/mdbook/config/index.html


### PR DESCRIPTION
Old link resulted in 404.  This PR make the link consistent with README.md in the book-example/src directory.