### PR TITLE
Don't strip relative path of additional javascript files

### DIFF
--- a/src/renderer/html_handlebars/hbs_renderer.rs
+++ b/src/renderer/html_handlebars/hbs_renderer.rs
@@ -422,13 +422,7 @@ fn make_data(
         for script in &html.additional_js {
             match script.strip_prefix(root) {
                 Ok(p) => js.push(p.to_str().expect("Could not convert to str")),
-                Err(_) => js.push(
-                    script
-                        .file_name()
-                        .expect("File has a file name")
-                        .to_str()
-                        .expect("Could not convert to str"),
-                ),
+                Err(_) => js.push(script.to_str().expect("Could not convert to str")),
             }
         }
         data.insert("additional_js".to_owned(), json!(js));


### PR DESCRIPTION
Previously, additional JavaScript files inside a directory were
correctly copied (with their parent created), but the link to it was
stripped of that parent.
There's no need for that (and it was not done for CSS)