### PR TITLE
avoid using `cd` in example travis-ci script

### DIFF
--- a/book-example/src/continuous-integration.md
+++ b/book-example/src/continuous-integration.md
@@ -26,7 +26,7 @@ before_script:
   - cargo install-update -a
 
 script:
-  - cd path/to/mybook && mdbook build && mdbook test
+  - mdbook build path/to/mybook && mdbook test path/to/mybook
 ```
 
 ## Deploying Your Book to GitHub Pages


### PR DESCRIPTION
I debugged 10 commits to figure out why the following failed
```
  - cd docs && mdbook build
  - cargo doc && cp -r target/doc docs/book/api
```
It should be
```
  - mdbook build docs
  - cargo doc && cp -r target/doc docs/book/api
```
