### PR TITLE
Default theme option

### DIFF
--- a/book-example/src/format/config.md
+++ b/book-example/src/format/config.md
@@ -132,7 +132,8 @@ The following configuration options are available:
 - **theme:** mdBook comes with a default theme and all the resource files needed
   for it. But if this option is set, mdBook will selectively overwrite the theme
   files with the ones found in the specified folder.
-- **default-theme:** The theme to be used by default. Defaults to `light`.
+- **default-theme:** The theme color scheme to select by default in the 
+  'Change Theme' dropdown. Defaults to `light`.
 - **curly-quotes:** Convert straight quotes to curly quotes, except for those
   that occur in code blocks and code spans. Defaults to `false`.
 - **google-analytics:** If you use Google Analytics, this option lets you enable

--- a/book-example/src/format/config.md
+++ b/book-example/src/format/config.md
@@ -132,6 +132,7 @@ The following configuration options are available:
 - **theme:** mdBook comes with a default theme and all the resource files needed
   for it. But if this option is set, mdBook will selectively overwrite the theme
   files with the ones found in the specified folder.
+- **default-theme:** The theme to be used by default. Defaults to `light`.
 - **curly-quotes:** Convert straight quotes to curly quotes, except for those
   that occur in code blocks and code spans. Defaults to `false`.
 - **google-analytics:** If you use Google Analytics, this option lets you enable

--- a/src/config.rs
+++ b/src/config.rs
@@ -570,6 +570,7 @@ mod tests {
 
         [output.html]
         theme = "./themedir"
+        default-theme = "rust"
         curly-quotes = true
         google-analytics = "123456"
         additional-css = ["./foo/bar/baz.css"]
@@ -609,6 +610,7 @@ mod tests {
             google_analytics: Some(String::from("123456")),
             additional_css: vec![PathBuf::from("./foo/bar/baz.css")],
             theme: Some(PathBuf::from("./themedir")),
+            default_theme: Some(String::from("rust")),
             playpen: playpen_should_be,
             ..Default::default()
         };

--- a/src/config.rs
+++ b/src/config.rs
@@ -415,6 +415,8 @@ impl Default for BuildConfig {
 pub struct HtmlConfig {
     /// The theme directory, if specified.
     pub theme: Option<PathBuf>,
+    /// The default theme to use, defaults to 'light'
+    pub default_theme: Option<String>,
     /// Use "smart quotes" instead of the usual `"` character.
     pub curly_quotes: bool,
     /// Should mathjax be enabled?

--- a/src/renderer/html_handlebars/hbs_renderer.rs
+++ b/src/renderer/html_handlebars/hbs_renderer.rs
@@ -214,6 +214,7 @@ impl HtmlHandlebars {
         );
         handlebars.register_helper("previous", Box::new(helpers::navigation::previous));
         handlebars.register_helper("next", Box::new(helpers::navigation::next));
+        handlebars.register_helper("theme_option", Box::new(helpers::theme::theme_option));
     }
 
     /// Copy across any additional CSS and JavaScript files which the book

--- a/src/renderer/html_handlebars/hbs_renderer.rs
+++ b/src/renderer/html_handlebars/hbs_renderer.rs
@@ -395,6 +395,12 @@ fn make_data(
         data.insert("livereload".to_owned(), json!(livereload));
     }
 
+    let default_theme = match html_config.default_theme {
+        Some(ref theme) => theme,
+        None => "light",
+    };
+    data.insert("default_theme".to_owned(), json!(default_theme));
+
     // Add google analytics tag
     if let Some(ref ga) = config.html_config().and_then(|html| html.google_analytics) {
         data.insert("google_analytics".to_owned(), json!(ga));

--- a/src/renderer/html_handlebars/helpers/mod.rs
+++ b/src/renderer/html_handlebars/helpers/mod.rs
@@ -1,2 +1,3 @@
 pub mod navigation;
 pub mod toc;
+pub mod theme;

--- a/src/renderer/html_handlebars/helpers/theme.rs
+++ b/src/renderer/html_handlebars/helpers/theme.rs
@@ -1,0 +1,30 @@
+use handlebars::{Context, Handlebars, Helper, Output, RenderContext, RenderError};
+
+pub fn theme_option(
+    h: &Helper,
+    _r: &Handlebars,
+    ctx: &Context,
+    rc: &mut RenderContext,
+    out: &mut Output,
+) -> Result<(), RenderError> {
+    trace!("theme_option (handlebars helper)");
+
+    let param = h
+        .param(0)
+        .and_then(|v| v.value().as_str())
+        .ok_or(RenderError::new(
+            "Param 0 with String type is required for theme_option helper.",
+        ))?;
+
+    let theme_name = rc
+        .evaluate_absolute(ctx, "default_theme", true)?
+        .as_str()
+        .ok_or_else(|| RenderError::new("Type error for `default_theme`, string expected"))?;
+
+    out.write(param)?;
+    if param.to_lowercase() == theme_name.to_lowercase() {
+        out.write(" (default)")?;
+    }
+
+    Ok(())
+}

--- a/src/theme/book.js
+++ b/src/theme/book.js
@@ -352,7 +352,7 @@ function playpen_text(playpen) {
 
         var previousTheme;
         try { previousTheme = localStorage.getItem('mdbook-theme'); } catch (e) { }
-        if (previousTheme === null || previousTheme === undefined) { previousTheme = 'light'; }
+        if (previousTheme === null || previousTheme === undefined) { previousTheme = default_theme; }
 
         try { localStorage.setItem('mdbook-theme', theme); } catch (e) { }
 
@@ -364,7 +364,7 @@ function playpen_text(playpen) {
     // Set theme
     var theme;
     try { theme = localStorage.getItem('mdbook-theme'); } catch(e) { }
-    if (theme === null || theme === undefined) { theme = 'light'; }
+    if (theme === null || theme === undefined) { theme = default_theme; }
 
     set_theme(theme);
 

--- a/src/theme/index.hbs
+++ b/src/theme/index.hbs
@@ -97,11 +97,11 @@
                                 <i class="fa fa-paint-brush"></i>
                             </button>
                             <ul id="theme-list" class="theme-popup" aria-label="Themes" role="menu">
-                                <li role="none"><button role="menuitem" class="theme" id="light">Light</button></li>
-                                <li role="none"><button role="menuitem" class="theme" id="rust">Rust</button></li>
-                                <li role="none"><button role="menuitem" class="theme" id="coal">Coal</button></li>
-                                <li role="none"><button role="menuitem" class="theme" id="navy">Navy</button></li>
-                                <li role="none"><button role="menuitem" class="theme" id="ayu">Ayu</button></li>
+                                <li role="none"><button role="menuitem" class="theme" id="light">{{ theme_option "Light" }}</button></li>
+                                <li role="none"><button role="menuitem" class="theme" id="rust">{{ theme_option "Rust" }}</button></li>
+                                <li role="none"><button role="menuitem" class="theme" id="coal">{{ theme_option "Coal" }}</button></li>
+                                <li role="none"><button role="menuitem" class="theme" id="navy">{{ theme_option "Navy" }}</button></li>
+                                <li role="none"><button role="menuitem" class="theme" id="ayu">{{ theme_option "Ayu" }}</button></li>
                             </ul>
                             {{#if search_enabled}}
                             <button id="search-toggle" class="icon-button" type="button" title="Search. (Shortkey: s)" aria-label="Toggle Searchbar" aria-expanded="false" aria-keyshortcuts="S" aria-controls="searchbar">

--- a/src/theme/index.hbs
+++ b/src/theme/index.hbs
@@ -35,9 +35,12 @@
         <script async type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script>
         {{/if}}
     </head>
-    <body class="light">
+    <body class="{{ default_theme }}">
         <!-- Provide site root to javascript -->
-        <script type="text/javascript">var path_to_root = "{{ path_to_root }}";</script>
+        <script type="text/javascript">
+            var path_to_root = "{{ path_to_root }}";
+            var default_theme = "{{ default_theme }}";
+        </script>
 
         <!-- Work around some values being stored in localStorage wrapped in quotes -->
         <script type="text/javascript">
@@ -59,7 +62,7 @@
         <script type="text/javascript">
             var theme;
             try { theme = localStorage.getItem('mdbook-theme'); } catch(e) { } 
-            if (theme === null || theme === undefined) { theme = 'light'; }
+            if (theme === null || theme === undefined) { theme = default_theme; }
             document.body.className = theme;
             document.querySelector('html').className = theme + ' js';
         </script>
@@ -94,7 +97,7 @@
                                 <i class="fa fa-paint-brush"></i>
                             </button>
                             <ul id="theme-list" class="theme-popup" aria-label="Themes" role="menu">
-                                <li role="none"><button role="menuitem" class="theme" id="light">Light <span class="default">(default)</span></button></li>
+                                <li role="none"><button role="menuitem" class="theme" id="light">Light</button></li>
                                 <li role="none"><button role="menuitem" class="theme" id="rust">Rust</button></li>
                                 <li role="none"><button role="menuitem" class="theme" id="coal">Coal</button></li>
                                 <li role="none"><button role="menuitem" class="theme" id="navy">Navy</button></li>


### PR DESCRIPTION
Opening a PR to initiate discussion.

Everything is there and working, but there are a few things I dislike/am unsure of.

1. Calling this option `default-theme` is confusing to the user. The options are presented as 'themes' to the visitor in the theme popup, but from a user's perspective the theme is the whole theme inside `src\theme`. Maybe this should be `default-style` or `default-theme-style`? Maybe I just need to explain the option better in the documentation?
2. I created a new handlebars helper to append ` (default)` to the selected default theme in the theme popup. Originally I had done this in the [javascript that sets the theme on page load](https://github.com/rust-lang-nursery/mdBook/blob/396426662de5ff6a9f12b8892ef89eba17b3bba2/src/theme/index.hbs#L57-L61), but it seemed a bit hacky when we know which theme is the default during render. Not sure if this is the best way, or best implementation of a helper though.
3. I have left the ordering of the theme popup as it is, but this means the default may now not be the top item. Should we re-order the list of themes to always have the default as the first item?

Once complete this will resolve #95 and #713 