### PR TITLE
Improve documentation comments

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -436,7 +436,7 @@ pub struct HtmlConfig {
     /// This config item *should not be edited* by the end user.
     #[doc(hidden)]
     pub livereload_url: Option<String>,
-    /// Should section labels be rendered?
+    /// Don't render section labels.
     pub no_section_label: bool,
     /// Search settings. If `None`, the default will be used.
     pub search: Option<Search>,


### PR DESCRIPTION
It is quite confusing that you should assign `true`, when the answer to the documentation comment is actually *"no"*.