### PR TITLE
fix(css/chrome): Use standard property for scrollbar

### DIFF
--- a/src/theme/css/chrome.css
+++ b/src/theme/css/chrome.css
@@ -8,7 +8,9 @@
 ::-webkit-scrollbar-thumb {
     background: var(--scrollbar);
 }
-
+html {
+    scrollbar-color: var(--scrollbar) var(--bg);
+}
 #searchresults a,
 .content a:link,
 a:visited,


### PR DESCRIPTION
This was recently standardized and is currently implemented in Firefox Nightly.