### PR TITLE
Change default code font-size to 0.8em

### DIFF
--- a/src/theme/css/general.css
+++ b/src/theme/css/general.css
@@ -17,7 +17,7 @@ body {
 
 code {
     font-family: "Source Code Pro", Consolas, "Ubuntu Mono", Menlo, "DejaVu Sans Mono", monospace, monospace;
-    font-size: 0.875em; /* please adjust the ace font size accordingly in editor.js */
+    font-size: 0.8em; /* please adjust the ace font size accordingly in editor.js */
 }
 
 .left { float: left; }

--- a/src/theme/playpen_editor/editor.js
+++ b/src/theme/playpen_editor/editor.js
@@ -13,7 +13,7 @@ window.editors = [];
             showLineNumbers: false,
             showGutter: false,
             maxLines: Infinity,
-            fontSize: "0.8em" // please adjust the font size of the code in general.styl
+            fontSize: "0.8em" // please adjust the font size of the code in general.css
         });
 
         editor.$blockScrolling = Infinity;

--- a/src/theme/playpen_editor/editor.js
+++ b/src/theme/playpen_editor/editor.js
@@ -13,7 +13,7 @@ window.editors = [];
             showLineNumbers: false,
             showGutter: false,
             maxLines: Infinity,
-            fontSize: "0.875em" // please adjust the font size of the code in general.styl
+            fontSize: "0.8em" // please adjust the font size of the code in general.styl
         });
 
         editor.$blockScrolling = Infinity;


### PR DESCRIPTION
This resolves weird rendering behavior in Chrome and Safari on macOS.
This is most likely because of some floating point rounding error.

---
### Before
<img width="785" alt="screenshot 2018-11-08 at 20 37 45" src="https://user-images.githubusercontent.com/29740439/48222979-43639780-e396-11e8-906f-b6b023df6a4e.png">

### After
<img width="785" alt="screenshot 2018-11-08 at 19 18 45" src="https://user-images.githubusercontent.com/29740439/48222970-3f377a00-e396-11e8-8c00-f9a0fc13d3ad.png">