### PR TITLE
Change overflow-x to initial

### DIFF
--- a/src/theme/css/chrome.css
+++ b/src/theme/css/chrome.css
@@ -181,6 +181,7 @@ html:not(.sidebar-visible) #menu-bar:not(:hover).folded > #menu-bar-sticky-conta
     padding: 0.1em 0.3em;
     border-radius: 3px;
     color: var(--inline-code-color);
+    overflow-x: initial;
 }
 
 a:hover > .hljs {


### PR DESCRIPTION
This resolves weird rendering behavior in Chrome and Safari on macOS.

---
### Before
<img width="785" alt="screenshot 2018-11-08 at 20 37 45" src="https://user-images.githubusercontent.com/29740439/48222979-43639780-e396-11e8-906f-b6b023df6a4e.png">

### After
<img width="785" alt="screenshot 2018-11-08 at 19 18 45" src="https://user-images.githubusercontent.com/29740439/48222970-3f377a00-e396-11e8-8c00-f9a0fc13d3ad.png">