### PR TITLE
Fix #823: Apply default padding to table headers

### DIFF
--- a/src/theme/css/general.css
+++ b/src/theme/css/general.css
@@ -92,6 +92,9 @@ table thead td {
     font-weight: 700;
     border: none;
 }
+table thead th {
+    padding: 3px 20px;
+}
 table thead tr {
     border: 1px var(--table-header-bg) solid;
 }


### PR DESCRIPTION
This PR fixes #823 by applying the default padding for table cells (`padding: 3px 20px;`) to header cells.