### PR TITLE
Fix invalid url in renderer documentation

### DIFF
--- a/src/renderer/mod.rs
+++ b/src/renderer/mod.rs
@@ -8,7 +8,7 @@
 //!
 //! The definition for [RenderContext] may be useful though.
 //!
-//! [For Developers]: https://rust-lang-nursery.github.io/mdBook/lib/index.html
+//! [For Developers]: https://rust-lang-nursery.github.io/mdBook/for_developers/index.html
 //! [RenderContext]: struct.RenderContext.html
 
 pub use self::html_handlebars::HtmlHandlebars;


### PR DESCRIPTION
The original link is no longer working.