### PR TITLE
Add include by anchor in preprocessor (partial include)

### DIFF
--- a/book-example/src/format/mdbook.md
+++ b/book-example/src/format/mdbook.md
@@ -63,6 +63,50 @@ the file are omitted. The third command includes all lines from line 2, i.e. the
 first line is omitted. The last command includes the excerpt of `file.rs`
 consisting of lines 2 to 10.
 
+To avoid breaking your book when modifying included files, you can also
+include a specific section using anchors instead of line numbers.
+An anchor is a pair of matching lines. The line beginning an anchor must
+match the regex "ANCHOR:\s*[\w_-]+" and similarly the ending line must match
+the regex "ANCHOR_END:\s*[\w_-]+". This allows you to put anchors in
+any kind of commented line.
+
+Consider the following file to include:
+```rs
+/* ANCHOR: all */
+
+// ANCHOR: component
+struct Paddle {
+    hello: f32,
+}
+// ANCHOR_END: component
+
+////////// ANCHOR: system
+impl System for MySystem { ... }
+////////// ANCHOR_END: system
+
+/* ANCHOR_END: all */
+```
+
+Then in the book, all you have to do is:
+````hbs
+Here is a component:
+```rust,no_run,noplaypen
+\{{#include file.rs:component}}
+```
+
+Here is a system:
+```rust,no_run,noplaypen
+\{{#include file.rs:system}}
+```
+
+This is the full file.
+```rust,no_run,noplaypen
+\{{#include file.rs:all}}
+```
+````
+
+Lines containing anchor patterns inside the included anchor are ignored.
+
 ## Inserting runnable Rust files
 
 With the following syntax, you can insert runnable Rust files into your book:

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -11,7 +11,7 @@ use std::borrow::Cow;
 use std::fmt::Write;
 use std::path::Path;
 
-pub use self::string::take_lines;
+pub use self::string::{take_anchored_lines, take_lines};
 
 /// Replaces multiple consecutive whitespace characters with a single space character.
 pub fn collapse_whitespace(text: &str) -> Cow<'_, str> {

--- a/src/utils/string.rs
+++ b/src/utils/string.rs
@@ -1,4 +1,5 @@
 use itertools::Itertools;
+use regex::Regex;
 use std::ops::Bound::{Excluded, Included, Unbounded};
 use std::ops::RangeBounds;
 
@@ -17,9 +18,46 @@ pub fn take_lines<R: RangeBounds<usize>>(s: &str, range: R) -> String {
     }
 }
 
+/// Take anchored lines from a string.
+/// Lines containing anchor are ignored.
+pub fn take_anchored_lines(s: &str, anchor: &str) -> String {
+    lazy_static! {
+        static ref RE_START: Regex = Regex::new(r"ANCHOR:\s*(?P<anchor_name>[\w_-]+)").unwrap();
+        static ref RE_END: Regex = Regex::new(r"ANCHOR_END:\s*(?P<anchor_name>[\w_-]+)").unwrap();
+    }
+
+    let mut retained = Vec::<&str>::new();
+    let mut anchor_found = false;
+
+    for l in s.lines() {
+        if anchor_found {
+            match RE_END.captures(l) {
+                Some(cap) => {
+                    if &cap["anchor_name"] == anchor {
+                        break;
+                    }
+                }
+                None => {
+                    if !RE_START.is_match(l) {
+                        retained.push(l);
+                    }
+                }
+            }
+        } else {
+            if let Some(cap) = RE_START.captures(l) {
+                if &cap["anchor_name"] == anchor {
+                    anchor_found = true;
+                }
+            }
+        }
+    }
+
+    retained.join("\n")
+}
+
 #[cfg(test)]
 mod tests {
-    use super::take_lines;
+    use super::{take_anchored_lines, take_lines};
 
     #[test]
     fn take_lines_test() {
@@ -31,5 +69,34 @@ mod tests {
         // corner cases
         assert_eq!(take_lines(s, 4..3), "");
         assert_eq!(take_lines(s, ..100), s);
+    }
+
+    #[test]
+    fn take_anchored_lines_test() {
+        let s = "Lorem\nipsum\ndolor\nsit\namet";
+        assert_eq!(take_anchored_lines(s, "test"), "");
+
+        let s = "Lorem\nipsum\ndolor\nANCHOR_END: test\nsit\namet";
+        assert_eq!(take_anchored_lines(s, "test"), "");
+
+        let s = "Lorem\nipsum\nANCHOR: test\ndolor\nsit\namet";
+        assert_eq!(take_anchored_lines(s, "test"), "dolor\nsit\namet");
+        assert_eq!(take_anchored_lines(s, "something"), "");
+
+        let s = "Lorem\nipsum\nANCHOR: test\ndolor\nsit\namet\nANCHOR_END: test\nlorem\nipsum";
+        assert_eq!(take_anchored_lines(s, "test"), "dolor\nsit\namet");
+        assert_eq!(take_anchored_lines(s, "something"), "");
+
+        let s = "Lorem\nANCHOR: test\nipsum\nANCHOR: test\ndolor\nsit\namet\nANCHOR_END: test\nlorem\nipsum";
+        assert_eq!(take_anchored_lines(s, "test"), "ipsum\ndolor\nsit\namet");
+        assert_eq!(take_anchored_lines(s, "something"), "");
+
+        let s = "Lorem\nANCHOR:    test2\nipsum\nANCHOR: test\ndolor\nsit\namet\nANCHOR_END: test\nlorem\nANCHOR_END:test2\nipsum";
+        assert_eq!(
+            take_anchored_lines(s, "test2"),
+            "ipsum\ndolor\nsit\namet\nlorem"
+        );
+        assert_eq!(take_anchored_lines(s, "test"), "dolor\nsit\namet");
+        assert_eq!(take_anchored_lines(s, "something"), "");
     }
 }


### PR DESCRIPTION
For issue https://github.com/rust-lang-nursery/mdBook/issues/811.
I apologize for the late pull request.

I'm not super happy with
https://github.com/rust-lang-nursery/mdBook/pull/851/files#diff-d6ae283361f866777987f4630e148843R138
and
https://github.com/rust-lang-nursery/mdBook/pull/851/files#diff-182fe74cafd75eb44defddf4511f3591R70

Please, tell me what you think about the anchored syntax. I'll update the user guide after.

In current implementation, first anchor must match regex "ANCHOR:\s*[\w\d_-]+" and similarly the ending anchor must match "ANCHOR_END:\s*[\w\d_-]+". In included file:
```
/* ANCHOR: all */

// ANCHOR: component
struct Paddle {
    hello: f32,
}
// ANCHOR_END: component

////////// ANCHOR: system
impl System for MySystem { ... }
////////// ANCHOR_END: system

/* ANCHOR_END: all */
```

Then in the book:
```
```rust,no_run,noplaypen
{{#include file.rs:component}}
`` `

```rust,no_run,noplaypen
{{#include file.rs:system}}
`` `

```rust,no_run,noplaypen
{{#include file.rs:all}}
`` `
```

Lines containing anchor patterns inside the included anchor are ignored, as such the result is:

```rust
struct Paddle {
    hello: f32,
}
```

```rust
impl System for MySystem { ... }
```

```rust
struct Paddle {
    hello: f32,
}

impl System for MySystem { ... }
```