### PR TITLE
Add colored help

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -33,6 +33,7 @@ fn main() {
         .version(VERSION)
         .setting(AppSettings::GlobalVersion)
         .setting(AppSettings::ArgRequiredElseHelp)
+        .setting(AppSettings::ColoredHelp)
         .after_help(
             "For more information about a specific command, try `mdbook <command> --help`\n\
              The source code for mdBook is available at: https://github.com/rust-lang-nursery/mdBook",


### PR DESCRIPTION
I thought it was beautiful looking at the help of the fd command

## before
<img width="680" alt="2018-12-25 21 33 09" src="https://user-images.githubusercontent.com/23740172/50422361-73ef8a00-088d-11e9-976a-b1e7203a2963.png">

## after
<img width="711" alt="2018-12-25 21 43 00" src="https://user-images.githubusercontent.com/23740172/50422431-1445ae80-088e-11e9-8583-6e92f7e6547e.png">
