### PR TITLE
Fix more print.html links.

### DIFF
--- a/tests/dummy_book/src/second/nested.md
+++ b/tests/dummy_book/src/second/nested.md
@@ -2,3 +2,7 @@
 
 When we link to [the first section](../first/nested.md), it should work on
 both the print page and the non-print page.
+
+Link [outside](../../std/foo/bar.html).
+
+![Some image](../images/picture.png)

--- a/tests/rendered_output.rs
+++ b/tests/rendered_output.rs
@@ -119,7 +119,11 @@ fn check_correct_relative_links_in_print_page() {
 
     assert_contains_strings(
         first.join("print.html"),
-        &[r##"<a href="second/../first/nested.html">the first section</a>,"##],
+        &[
+            r##"<a href="second/../first/nested.html">the first section</a>,"##,
+            r##"<a href="second/../../std/foo/bar.html">outside</a>"##,
+            r##"<img src="second/../images/picture.png" alt="Some image" />"##,
+        ],
     );
 }
 

--- a/tests/searchindex_fixture.json
+++ b/tests/searchindex_fixture.json
@@ -66,7 +66,7 @@
           "title": 2
         },
         "9": {
-          "body": 10,
+          "body": 13,
           "breadcrumbs": 7,
           "title": 5
         }
@@ -133,7 +133,7 @@
           "title": "Second Chapter"
         },
         "9": {
-          "body": "When we link to the first section , it should work on both the print page and the non-print page.",
+          "body": "When we link to the first section , it should work on both the print page and the non-print page. Link outside . Some image",
           "breadcrumbs": "Second Chapter » Testing relative links for the print page",
           "id": "9",
           "title": "Testing relative links for the print page"
@@ -555,6 +555,22 @@
           "i": {
             "df": 0,
             "docs": {},
+            "m": {
+              "a": {
+                "df": 0,
+                "docs": {},
+                "g": {
+                  "df": 1,
+                  "docs": {
+                    "9": {
+                      "tf": 1.0
+                    }
+                  }
+                }
+              },
+              "df": 0,
+              "docs": {}
+            },
             "n": {
               "c": {
                 "df": 0,
@@ -715,7 +731,7 @@
                   "df": 1,
                   "docs": {
                     "9": {
-                      "tf": 1.4142135623730951
+                      "tf": 1.7320508075688772
                     }
                   }
                 }
@@ -840,6 +856,34 @@
                 "docs": {
                   "9": {
                     "tf": 1.0
+                  }
+                }
+              }
+            }
+          },
+          "o": {
+            "df": 0,
+            "docs": {},
+            "u": {
+              "df": 0,
+              "docs": {},
+              "t": {
+                "df": 0,
+                "docs": {},
+                "s": {
+                  "df": 0,
+                  "docs": {},
+                  "i": {
+                    "d": {
+                      "df": 1,
+                      "docs": {
+                        "9": {
+                          "tf": 1.0
+                        }
+                      }
+                    },
+                    "df": 0,
+                    "docs": {}
                   }
                 }
               }
@@ -1732,6 +1776,22 @@
           "i": {
             "df": 0,
             "docs": {},
+            "m": {
+              "a": {
+                "df": 0,
+                "docs": {},
+                "g": {
+                  "df": 1,
+                  "docs": {
+                    "9": {
+                      "tf": 1.0
+                    }
+                  }
+                }
+              },
+              "df": 0,
+              "docs": {}
+            },
             "n": {
               "c": {
                 "df": 0,
@@ -1892,7 +1952,7 @@
                   "df": 1,
                   "docs": {
                     "9": {
-                      "tf": 1.7320508075688772
+                      "tf": 2.0
                     }
                   }
                 }
@@ -2017,6 +2077,34 @@
                 "docs": {
                   "9": {
                     "tf": 1.0
+                  }
+                }
+              }
+            }
+          },
+          "o": {
+            "df": 0,
+            "docs": {},
+            "u": {
+              "df": 0,
+              "docs": {},
+              "t": {
+                "df": 0,
+                "docs": {},
+                "s": {
+                  "df": 0,
+                  "docs": {},
+                  "i": {
+                    "d": {
+                      "df": 1,
+                      "docs": {
+                        "9": {
+                          "tf": 1.0
+                        }
+                      }
+                    },
+                    "df": 0,
+                    "docs": {}
                   }
                 }
               }


### PR DESCRIPTION
- Rewrite relative links that point to non-markdown files like images (fixes #789).
- Rewrite relative links that go outside of the book. Several Rust books use
  links like `../../std/ops/trait.Index.html` and these need to be rewritten,
  too.
