### PR TITLE
Fix deploy on Travis.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,19 @@
 language: rust
 
-rust:
-  - stable
-  - beta
-  - nightly
+matrix:
+  include:
+    - rust: stable
+      env: TARGET=x86_64-unknown-linux-gnu
+    - rust: beta
+      env: TARGET=x86_64-unknown-linux-gnu
+    - rust: nightly
+      env: TARGET=x86_64-unknown-linux-gnu
 
-os:
-  - linux
-  - osx
+    - rust: stable
+      os: osx
+      env: TARGET=x86_64-apple-darwin
 
-cache: 
+cache:
   timeout: 360
   cargo: true
 


### PR DESCRIPTION
The deploy scripts require TARGET env var to be set, but it wasn't set anywhere, causing it to fail: https://travis-ci.com/rust-lang-nursery/mdBook/builds/97850452.

This also reduces the number of mac builders, since they aren't necessary, and capacity is limited.

The api key will likely need to be updated, too, since the transition to travis.com.

Appveyor also seems to be broken, but I suspect it is also a key issue.