### PR TITLE
Some refactors for handlebar renderer

### DIFF
--- a/src/renderer/html_handlebars/hbs_renderer.rs
+++ b/src/renderer/html_handlebars/hbs_renderer.rs
@@ -65,7 +65,7 @@ impl HtmlHandlebars {
         Ok(rendered)
     }
 
-    fn render_item(
+    fn process_item(
         &self,
         item: &BookItem,
         mut ctx: RenderItemContext,
@@ -343,7 +343,7 @@ impl Renderer for HtmlHandlebars {
                 is_index,
                 html_config: html_config.clone(),
             };
-            self.render_item(item, ctx, &mut print_content)?;
+            self.process_item(item, ctx, &mut print_content)?;
             is_index = false;
         }
 

--- a/src/renderer/html_handlebars/hbs_renderer.rs
+++ b/src/renderer/html_handlebars/hbs_renderer.rs
@@ -284,11 +284,6 @@ impl Renderer for HtmlHandlebars {
         trace!("render");
         let mut handlebars = Handlebars::new();
 
-        let theme_dir = match html_config.theme {
-            Some(ref theme) => theme.to_path_buf(),
-            None => ctx.root.join("theme"),
-        };
-
         if html_config.theme.is_none()
             && maybe_wrong_theme_dir(&src_dir.join("theme")).unwrap_or(false)
         {
@@ -298,6 +293,11 @@ impl Renderer for HtmlHandlebars {
             );
             warn!("Please move your theme files to `./theme` for them to continue being used");
         }
+
+        let theme_dir = match html_config.theme {
+            Some(ref theme) => theme.to_path_buf(),
+            None => ctx.root.join("theme"),
+        };
 
         let theme = theme::Theme::new(theme_dir);
 

--- a/src/renderer/html_handlebars/hbs_renderer.rs
+++ b/src/renderer/html_handlebars/hbs_renderer.rs
@@ -282,8 +282,6 @@ impl Renderer for HtmlHandlebars {
         let book = &ctx.book;
 
         trace!("render");
-        let mut handlebars = Handlebars::new();
-
         if html_config.theme.is_none()
             && maybe_wrong_theme_dir(&src_dir.join("theme")).unwrap_or(false)
         {
@@ -300,6 +298,8 @@ impl Renderer for HtmlHandlebars {
         };
 
         let theme = theme::Theme::new(theme_dir);
+
+        let mut handlebars = Handlebars::new();
 
         debug!("Register the index handlebars template");
         handlebars.register_template_string("index", String::from_utf8(theme.index.clone())?)?;

--- a/src/renderer/html_handlebars/hbs_renderer.rs
+++ b/src/renderer/html_handlebars/hbs_renderer.rs
@@ -29,7 +29,8 @@ impl HtmlHandlebars {
 
     fn render_page(&self, content: &str, ctx: &RenderPageContext) -> Result<String> {
         let title = {
-            let book_title = ctx.data
+            let book_title = ctx
+                .data
                 .get("book_title")
                 .and_then(serde_json::Value::as_str)
                 .unwrap_or("");
@@ -68,14 +69,18 @@ impl HtmlHandlebars {
     fn process_item(
         &self,
         item: &BookItem,
-        mut ctx: RenderItemContext,
+        ctx: RenderItemContext,
         print_content: &mut String,
     ) -> Result<()> {
         // FIXME: This should be made DRY-er and rely less on mutable state
         if let BookItem::Chapter(ref ch) = *item {
             let string_path = ch.path.parent().unwrap().display().to_string();
 
-            let fixed_content = utils::render_markdown_with_base(&ch.content, ctx.html_config.curly_quotes, &string_path);
+            let fixed_content = utils::render_markdown_with_base(
+                &ch.content,
+                ctx.html_config.curly_quotes,
+                &string_path,
+            );
             print_content.push_str(&fixed_content);
 
             // Update the context with data for this file
@@ -107,7 +112,10 @@ impl HtmlHandlebars {
             utils::fs::write_file(&ctx.destination, &filepath, rendered.as_bytes())?;
 
             if ctx.is_index {
-                let page_context = RenderPageContext { is_index: true, ..page_context };
+                let page_context = RenderPageContext {
+                    is_index: true,
+                    ..page_context
+                };
                 let rendered_index = self.render_page(&rendered_md, &page_context)?;
                 debug!("Creating index.html from {}", path);
                 utils::fs::write_file(&ctx.destination, "index.html", rendered_index.as_bytes())?;


### PR DESCRIPTION
- Moved creation and configuration handlebars to function.
- Separated `render_item` to render markdown and render page steps

Next steps:
- separate rendering and writing pages, maybe separate parsing step (for create AST and have ability render to html/plain text/xml/etc)
- adding tests