### PR TITLE
Expose API for building a book with a custom Summary.

### DIFF
--- a/src/book/book.rs
+++ b/src/book/book.rs
@@ -179,7 +179,7 @@ impl Chapter {
 ///
 /// You need to pass in the book's source directory because all the links in
 /// `SUMMARY.md` give the chapter locations relative to it.
-fn load_book_from_disk<P: AsRef<Path>>(summary: &Summary, src_dir: P) -> Result<Book> {
+pub(crate) fn load_book_from_disk<P: AsRef<Path>>(summary: &Summary, src_dir: P) -> Result<Book> {
     debug!("Loading the book from disk");
     let src_dir = src_dir.as_ref();
 

--- a/src/book/mod.rs
+++ b/src/book/mod.rs
@@ -95,6 +95,29 @@ impl MDBook {
         })
     }
 
+    /// Load a book from its root directory using a custom config and a custom summary.
+    pub fn load_with_config_and_summary<P: Into<PathBuf>>(
+        book_root: P,
+        config: Config,
+        summary: Summary
+    ) -> Result<MDBook> {
+        let root = book_root.into();
+
+        let src_dir = root.join(&config.book.src);
+        let book = book::load_book_from_disk(&summary, &src_dir)?;
+
+        let renderers = determine_renderers(&config);
+        let preprocessors = determine_preprocessors(&config)?;
+
+        Ok(MDBook {
+            root,
+            config,
+            book,
+            renderers,
+            preprocessors,
+        })
+    }
+
     /// Returns a flat depth-first iterator over the elements of the book,
     /// it returns an [BookItem enum](bookitem.html):
     /// `(section: String, bookitem: &BookItem)`


### PR DESCRIPTION
This is useful for situations where you'd like to supplement or replace the existing Summary parsing with
custom filesystem traversal code or other similar changes.

In this context, a Summary is almost a "build rules" input for the book, so that an embedder can use their own layout while still benefiting from the actual file reading/parsing/etc provided by mdbook.