### PR TITLE
add docs for publishing to github pages manually

### DIFF
--- a/book-example/src/continuous-integration.md
+++ b/book-example/src/continuous-integration.md
@@ -58,7 +58,8 @@ That's it!
 ### Deploying to GitHub Pages manually
 
 If you're CI doesn't support a GitHub pages, or you're deploying somewhere else
-with GitHub pages like integration, *note: you may want to use different tmp dirs*:
+with integrations such as Github Pages: 
+ *note: you may want to use different tmp dirs*:
 
 ```console
 $> git worktree add /tmp/book gh-pages

--- a/book-example/src/continuous-integration.md
+++ b/book-example/src/continuous-integration.md
@@ -57,7 +57,7 @@ That's it!
 
 ### Deploying to GitHub Pages manually
 
-If your CI doesn't support a GitHub pages, or you're deploying somewhere else
+If your CI doesn't support GitHub pages, or you're deploying somewhere else
 with integrations such as Github Pages: 
  *note: you may want to use different tmp dirs*:
 

--- a/book-example/src/continuous-integration.md
+++ b/book-example/src/continuous-integration.md
@@ -54,3 +54,35 @@ deploy:
 ```
 
 That's it!
+
+### Deploying to GitHub Pages manually
+
+If you're CI doesn't support a GitHub pages, or you're deploying somewhere else
+with GitHub pages like integration, *note: you may want to use different tmp dirs*:
+
+```console
+$> git worktree add /tmp/book gh-pages
+$> mdbook build
+$> rm -rf /tmp/book/* # this won't delete the .git directory
+$> cp -rp book/* /tmp/book/
+$> cd /tmp/book
+$> git add -A
+$> git commit 'new book message'
+$> git push origin gh-pages
+$> cd -
+```
+
+Or put this into a Makefile rule:
+
+```makefile
+.PHONY: deploy
+deploy: book
+	@echo "====> deploying to github"
+	git worktree add /tmp/book gh-pages
+	rm -rf /tmp/book/*
+	cp -rp book/* /tmp/book/
+	cd /tmp/book && \
+		git add -A && \
+		git commit -m "deployed on $(shell date) by ${USER}" && \
+		git push origin gh-pages
+```

--- a/book-example/src/continuous-integration.md
+++ b/book-example/src/continuous-integration.md
@@ -57,7 +57,7 @@ That's it!
 
 ### Deploying to GitHub Pages manually
 
-If you're CI doesn't support a GitHub pages, or you're deploying somewhere else
+If your CI doesn't support a GitHub pages, or you're deploying somewhere else
 with integrations such as Github Pages: 
  *note: you may want to use different tmp dirs*:
 


### PR DESCRIPTION
I had some trouble with the way that mdbook cleans the target directory, this documents how I worked around that. I'll try and come up with a patch for clean, that leaves `.git` in tact.