### PR TITLE
Write preprocessed content to file before testing with rustdoc

### DIFF
--- a/src/book/mod.rs
+++ b/src/book/mod.rs
@@ -242,13 +242,12 @@ impl MDBook {
             if let BookItem::Chapter(ref ch) = *item {
                 if !ch.path.as_os_str().is_empty() {
                     let path = self.source_dir().join(&ch.path);
-                    let content = utils::fs::file_to_string(&path)?;
                     info!("Testing file: {:?}", path);
 
                     // write preprocessed file to tempdir
                     let path = temp_dir.path().join(&ch.path);
                     let mut tmpf = utils::fs::create_file(&path)?;
-                    tmpf.write_all(content.as_bytes())?;
+                    tmpf.write_all(ch.content.as_bytes())?;
 
                     let output = Command::new("rustdoc")
                         .arg(&path)

--- a/tests/dummy_book/mod.rs
+++ b/tests/dummy_book/mod.rs
@@ -58,8 +58,11 @@ impl DummyBook {
         })?;
 
         let sub_pattern = if self.passing_test { "true" } else { "false" };
-        let file_containing_test = temp.path().join("src/first/nested.md");
-        replace_pattern_in_file(&file_containing_test, "$TEST_STATUS", sub_pattern)?;
+        let files_containing_tests = ["src/first/nested.md", "src/first/nested-test.rs"];
+        for file in &files_containing_tests {
+            let path_containing_tests = temp.path().join(file);
+            replace_pattern_in_file(&path_containing_tests, "$TEST_STATUS", sub_pattern)?;
+        }
 
         Ok(temp)
     }

--- a/tests/dummy_book/src/first/nested-test.rs
+++ b/tests/dummy_book/src/first/nested-test.rs
@@ -1,0 +1,1 @@
+assert!($TEST_STATUS);

--- a/tests/dummy_book/src/first/nested.md
+++ b/tests/dummy_book/src/first/nested.md
@@ -7,3 +7,7 @@ assert!($TEST_STATUS);
 ```
 
 ## Some Section
+
+```rust
+{{#include nested-test.rs}}
+```

--- a/tests/searchindex_fixture.json
+++ b/tests/searchindex_fixture.json
@@ -46,7 +46,7 @@
           "title": 2
         },
         "5": {
-          "body": 0,
+          "body": 1,
           "breadcrumbs": 3,
           "title": 1
         },
@@ -109,7 +109,7 @@
           "title": "Nested Chapter"
         },
         "5": {
-          "body": "",
+          "body": "assert!(true);",
           "breadcrumbs": "First Chapter » Some Section",
           "id": "5",
           "title": "Some Section"
@@ -177,9 +177,12 @@
                               "df": 0,
                               "docs": {},
                               "u": {
-                                "df": 1,
+                                "df": 2,
                                 "docs": {
                                   "4": {
+                                    "tf": 1.0
+                                  },
+                                  "5": {
                                     "tf": 1.0
                                   }
                                 }
@@ -1336,9 +1339,12 @@
                               "df": 0,
                               "docs": {},
                               "u": {
-                                "df": 1,
+                                "df": 2,
                                 "docs": {
                                   "4": {
+                                    "tf": 1.0
+                                  },
+                                  "5": {
                                     "tf": 1.0
                                   }
                                 }


### PR DESCRIPTION
Rather than writing the unpreprocessed content to the file for rustdoc to test with.

Fixes #855.

I was trying to figure out whether the current behavior was intentional or not, and if I might be breaking anything with this change, but I think the fix I have here is what was intended-- my first hint was [this comment](https://github.com/rust-lang-nursery/mdBook/blob/c068703028d19fb6c5a4690e904ae6f2bd74292f/src/book/mod.rs#L248) that described what I had hoped was happening but that wasn't what was actually happening.

As of [this commit](https://github.com/rust-lang-nursery/mdBook/commit/ddf31dcc086ffc45defebfd30aa0de8b318f7348), it seems like the behavior I was hoping for was happening and was intended ("now `mdbook test` does full link expansion to temp file prior to running" in the commit message), but [this line got lost in refactoring](https://github.com/rust-lang-nursery/mdBook/commit/cad76a9f6c#diff-dbfdf1ed62f03d8bae38d1b1177880c9L226) and [the preprocessors were being run](https://github.com/rust-lang-nursery/mdBook/commit/cad76a9f6c#diff-dbfdf1ed62f03d8bae38d1b1177880c9R222) but [this line](https://github.com/rust-lang-nursery/mdBook/commit/cad76a9f6c#diff-dbfdf1ed62f03d8bae38d1b1177880c9R229) read the unprocessed file from disk again and gave that content to rustdoc :(

If this fails CI I will fix it tomorrow ❤️ 	