### PR TITLE
Fix deprecation warnings for trim left/right matches

### DIFF
--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -61,7 +61,7 @@ pub fn id_from_content(content: &str) -> String {
     }
 
     // Remove spaces and hashes indicating a header
-    let trimmed = content.trim().trim_left_matches('#').trim();
+    let trimmed = content.trim().trim_start_matches('#').trim();
 
     normalize_id(trimmed)
 }

--- a/tests/rendered_output.rs
+++ b/tests/rendered_output.rs
@@ -423,8 +423,8 @@ mod search {
     fn read_book_index(root: &Path) -> serde_json::Value {
         let index = root.join("book/searchindex.js");
         let index = file_to_string(index).unwrap();
-        let index = index.trim_left_matches("window.search = ");
-        let index = index.trim_right_matches(";");
+        let index = index.trim_start_matches("window.search = ");
+        let index = index.trim_end_matches(";");
         serde_json::from_str(&index).unwrap()
     }
 


### PR DESCRIPTION
There's still a deprecation warning for `Error::source` that [comes from error-chain](https://github.com/rust-lang-nursery/error-chain/pull/255), but this fixes warnings originating in mdBook's code, at least.