### PR TITLE
Fix color of `code spans` that are links.

### DIFF
--- a/src/theme/css/chrome.css
+++ b/src/theme/css/chrome.css
@@ -180,6 +180,9 @@ html:not(.sidebar-visible) #menu-bar:not(:hover).folded > #menu-bar-sticky-conta
     vertical-align: middle;
     padding: 0.1em 0.3em;
     border-radius: 3px;
+}
+
+:not(pre):not(a) > .hljs {
     color: var(--inline-code-color);
 }
 


### PR DESCRIPTION
Linked code span colors were fixed in #289, but the fix was lost in #315 when inline code colors were added.  The issue (I believe) is that the specificity of `:not(pre) > .hljs` is greater than `a > .hljs`.  I added a new rule which applies the inline color, but excludes `a` tags.

Fixes #537

This is has been reported in several other places: https://github.com/rust-lang/book/issues/1115, https://github.com/rust-lang/cargo/issues/6862

Theme | Example
------ | ----------
Light | <img width="426" alt="image" src="https://user-images.githubusercontent.com/43198/57096981-57e07700-6ccb-11e9-9c8e-43bb6ccbc3d8.png">
Rust | <img width="427" alt="image" src="https://user-images.githubusercontent.com/43198/57097004-6b8bdd80-6ccb-11e9-8f63-e1153ad5edac.png">
Coal | <img width="431" alt="image" src="https://user-images.githubusercontent.com/43198/57097022-77779f80-6ccb-11e9-92d3-994597c4dfcd.png">
Navy | <img width="433" alt="image" src="https://user-images.githubusercontent.com/43198/57097036-80687100-6ccb-11e9-9d86-ea63bfff32c1.png">
Ayu | <img width="433" alt="image" src="https://user-images.githubusercontent.com/43198/57097051-88c0ac00-6ccb-11e9-9fcf-5d0a74df245a.png">
