### PR TITLE
Automatic deploy to gh-pages and gh release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ env:
     - CRATE_NAME=mdbook
 
 matrix:
+  fast_finish: true
   include:
     - rust: stable
       env: TARGET=x86_64-unknown-linux-gnu
@@ -47,17 +48,25 @@ script:
 
 before_deploy:
   - sh ci/before_deploy.sh
+  - target/"$TARGET"/release/mdbook build book-example
 
 deploy:
-  provider: releases
-  api_key:
-    - secure: cURRWBr034iqBz/ifD7uOunBfNR30YxIXfgLX0osWz+iafkVbhDGYYz9sBmRraqO2P7L2koEXMADVb/md1kI2+ykiq/ml+l9zuEAZPVmvSGUN7ZD+7s+lu3l5OBPG5z175T+b2q2q2m8XVR7TW20ra4QbE0bq06KAoOyjSgQVBTSCYsL9uTsGwiVRMEqqJT/BmKhKJNkpGsTKyBSKkOXvfeAAbE260vXUDEN9TYdJ3fvteRrpwLX56ee64gIZUq0RjDc4SKIEqilM6iUtNMvurqaewYNGkiXKRruV6BPCHxEHo6NNT46kOJLBJTf7gZw//dWhSoWpg9P0gdAnPWm407kSa3F7aJ1eRShAFQ4BLyfz9efTqm+jP3fOp7Mm7igSh9w6caSRuOnSsUf5+raRQ8E5Y9HsWGzzpZQk24Fx9EGZ04EeDSdpZAFz+jcbMpHf8t2p4CEx0CCNwYvKx6EydMKbMF5QteQ8SQkXNLhv7Rz2OgtXWYZPRVCMfQfOplsi2InsLCrQxTgwh+6u654SqVSgaHG+IncEAxBrdWy4rHcg7qereUcKfcY3k96vaDxdn/T2c00Ig0aNFR91YnixGMd6J6tQgDcRK9jh6fUm1CCBE9hT+pNUmtgYKuWBoLZexUZFFnfuBed0WciBot1bGDDamndqKq0jJiAzg+GMHk=
-  file_glob: true
-  file: "$CRATE_NAME-$TRAVIS_TAG-$TARGET.*"
-  on:
-    condition: "$TRAVIS_RUST_VERSION = stable"
-    tags: true
-  skip_cleanup: true
+  - provider: releases
+    api_key: "$GITHUB_OAUTH_TOKEN"
+    file_glob: true
+    file: "$CRATE_NAME-$TRAVIS_TAG-$TARGET.*"
+    skip_cleanup: true
+    on:
+      condition: "$TRAVIS_RUST_VERSION = stable"
+      tags: true
+  - provider: pages
+    skip-cleanup: true
+    local-dir: book-example/book
+    github-token: "$GITHUB_OAUTH_TOKEN"
+    keep-history: false
+    on:
+      branch: master
+      condition: $TRAVIS_OS_NAME = "linux" && $TRAVIS_RUST_VERSION = "stable"
 
 branches:
   only:


### PR DESCRIPTION
You need to set up [GitHub person access token](https://github.com/settings/tokens)
![image](https://user-images.githubusercontent.com/15225902/57208701-6ac2b680-6fff-11e9-9d31-5376abc8941a.png)
then save it in [Travis settings](https://travis-ci.org/m4b/goblin/settings) under the name `GITHUB_OAUTH_TOKEN`.

The old key should be revoked or reused if needed.

Demo is at:
* https://github.com/lzutao/mdBook/releases/tag/v0.2.4
* https://lzutao.github.io/mdBook/

r? @Dylan-DPC 

Closes #904 .
