### PR TITLE
Fix keyboard chapter navigation for `file` urls.

### DIFF
--- a/src/renderer/html_handlebars/search.rs
+++ b/src/renderer/html_handlebars/search.rs
@@ -35,7 +35,7 @@ pub fn create_files(search_config: &Search, destination: &Path, book: &Book) -> 
         utils::fs::write_file(
             destination,
             "searchindex.js",
-            format!("window.search = {};", index).as_bytes(),
+            format!("Object.assign(window.search, {});", index).as_bytes(),
         )?;
         utils::fs::write_file(destination, "searcher.js", searcher::JS)?;
         utils::fs::write_file(destination, "mark.min.js", searcher::MARK_JS)?;

--- a/tests/rendered_output.rs
+++ b/tests/rendered_output.rs
@@ -427,8 +427,8 @@ mod search {
     fn read_book_index(root: &Path) -> serde_json::Value {
         let index = root.join("book/searchindex.js");
         let index = file_to_string(index).unwrap();
-        let index = index.trim_start_matches("window.search = ");
-        let index = index.trim_end_matches(';');
+        let index = index.trim_start_matches("Object.assign(window.search, ");
+        let index = index.trim_end_matches(");");
         serde_json::from_str(&index).unwrap()
     }
 


### PR DESCRIPTION
This fixes it so that keyboard navigation should work when loading a book from a `file://` url.

When loading the search index, if it fails due to a CORS error (such as when loading json from `file://`), it will load the `searchindex.js` version instead [here](https://github.com/rust-lang-nursery/mdBook/blob/7ab939f8f29a7e0cebcf1e573f6c393b185ffa89/src/theme/searcher/searcher.js#L468-L473). However, this was written to replace the `window.search` object which loses the [`hasFocus`](https://github.com/rust-lang-nursery/mdBook/blob/7ab939f8f29a7e0cebcf1e573f6c393b185ffa89/src/theme/searcher/searcher.js#L476) method which caused the [keyboard handler](https://github.com/rust-lang-nursery/mdBook/blob/7ab939f8f29a7e0cebcf1e573f6c393b185ffa89/src/theme/book.js#L536) to fail because `hasFocus` was missing.

This changes it so that instead of replacing `window.search`, it just updates the existing object.

Fixes #910.