### PR TITLE
Fix "next" navigation on index.html.

### DIFF
--- a/src/renderer/html_handlebars/hbs_renderer.rs
+++ b/src/renderer/html_handlebars/hbs_renderer.rs
@@ -86,7 +86,7 @@ impl HtmlHandlebars {
             utils::fs::write_file(&ctx.destination, &filepath, rendered.as_bytes())?;
 
             if ctx.is_index {
-                ctx.data.insert("path".to_owned(), json!("index.html"));
+                ctx.data.insert("path".to_owned(), json!("index.md"));
                 ctx.data.insert("path_to_root".to_owned(), json!(""));
                 let rendered_index = ctx.handlebars.render("index", &ctx.data)?;
                 let rendered_index = self.post_process(rendered_index, &ctx.html_config.playpen);


### PR DESCRIPTION
The "next" link on `index.html` wasn't working because the navigation code was checking for `index.md` style links, but this was defining the page as `index.html`.  I didn't check, but I'm guessing this has been broken since mdbook switched to `.md` style links in 0.2.

Fixes #874.