### PR TITLE
Update mdbook 0.1 -> 0.2 in docs for CI

### DIFF
--- a/book-example/src/continuous-integration.md
+++ b/book-example/src/continuous-integration.md
@@ -22,7 +22,7 @@ rust:
 
 before_script:
   - (test -x $HOME/.cargo/bin/cargo-install-update || cargo install cargo-update)
-  - (test -x $HOME/.cargo/bin/mdbook || cargo install --vers "^0.1" mdbook)
+  - (test -x $HOME/.cargo/bin/mdbook || cargo install --vers "^0.2" mdbook)
   - cargo install-update -a
 
 script:


### PR DESCRIPTION
```diff
  - (test -x $HOME/.cargo/bin/cargo-install-update || cargo install cargo-update)
-  - (test -x $HOME/.cargo/bin/mdbook || cargo install --vers "^0.1" mdbook)
+  - (test -x $HOME/.cargo/bin/mdbook || cargo install --vers "^0.2" mdbook)
  - cargo install-update -a
```

Because otherwise people will ^C^V and `cargo install-update -a` will have to install mdbook again but with a newer version