### PR TITLE
Change language attribute of the book to configurable 

### DIFF
--- a/book-example/book.toml
+++ b/book-example/book.toml
@@ -2,6 +2,7 @@
 title = "mdBook Documentation"
 description = "Create book from markdown files. Like Gitbook but implemented in Rust"
 authors = ["Mathieu David", "Michael-F-Bryan"]
+language = "en"
 
 [output.html]
 mathjax-support = true

--- a/book-example/src/format/config.md
+++ b/book-example/src/format/config.md
@@ -42,6 +42,7 @@ This is general information about your book.
 - **src:** By default, the source directory is found in the directory named
   `src` directly under the root folder. But this is configurable with the `src`
   key in the configuration file.
+- **language:** The main language of the book, which is used as a language attribute `<html lang="en">` for example.
 
 **book.toml**
 ```toml
@@ -50,6 +51,7 @@ title = "Example book"
 authors = ["John Doe", "Jane Doe"]
 description = "The example book covers examples."
 src = "my-src"  # the source files will be found in `root/my-src` instead of `root/src`
+language = "en"
 ```
 
 ### Build options

--- a/book-example/src/format/theme/index-hbs.md
+++ b/book-example/src/format/theme/index-hbs.md
@@ -17,9 +17,8 @@ handlebars template you can access this information by using
 
 Here is a list of the properties that are exposed:
 
-- ***language*** Language of the book in the form `en`. To use in <code
-  class="language-html">\<html lang="{{ language }}"></code> for example. At the
-  moment it is hardcoded.
+- ***language*** Language of the book in the form `en`, as specified in `book.toml` (if not specified, defaults to `en`). To use in <code
+  class="language-html">\<html lang="{{ language }}"></code> for example.
 - ***title*** Title of the book, as specified in `book.toml`
 - ***chapter_title*** Title of the current chapter, as listed in `SUMMARY.md`
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -374,6 +374,8 @@ pub struct BookConfig {
     pub src: PathBuf,
     /// Does this book support more than one language?
     pub multilingual: bool,
+    /// The main language of the book.
+    pub language: Option<String>,
 }
 
 impl Default for BookConfig {
@@ -384,6 +386,7 @@ impl Default for BookConfig {
             description: None,
             src: PathBuf::from("src"),
             multilingual: false,
+            language: Some(String::from("en")),
         }
     }
 }
@@ -570,6 +573,7 @@ mod tests {
         description = "A completely useless book"
         multilingual = true
         src = "source"
+        language = "ja"
 
         [build]
         build-dir = "outputs"
@@ -604,6 +608,7 @@ mod tests {
             description: Some(String::from("A completely useless book")),
             multilingual: true,
             src: PathBuf::from("source"),
+            language: Some(String::from("ja")),
         };
         let build_should_be = BuildConfig {
             build_dir: PathBuf::from("outputs"),

--- a/src/renderer/html_handlebars/hbs_renderer.rs
+++ b/src/renderer/html_handlebars/hbs_renderer.rs
@@ -381,7 +381,10 @@ fn make_data(
     let html = config.html_config().unwrap_or_default();
 
     let mut data = serde_json::Map::new();
-    data.insert("language".to_owned(), json!("en"));
+    data.insert(
+        "language".to_owned(),
+        json!(config.book.language.clone().unwrap_or_default()),
+    );
     data.insert(
         "book_title".to_owned(),
         json!(config.book.title.clone().unwrap_or_default()),


### PR DESCRIPTION
Currently the language attribute of the book, which is used like `<html lang={{ language }}>`, is hardcoded as fixed value `en`.
I want to use mdBook in Japanese, so make it configurable.

With these changes, we will be able to set the language of the book like:

`book.toml`

```toml
[book]
title = "the title of the book"
authors = ["rnitta"]
src = "src"
language = "ja"
```

The default value of the language is still `en`, and no changes of `book.toml` is required if you want to set language `en` as same as usual.