### PR TITLE
Update css to support diff syntax highlighting.

### DIFF
--- a/src/theme/ayu-highlight.css
+++ b/src/theme/ayu-highlight.css
@@ -69,3 +69,11 @@ Original by Dempfi (https://github.com/dempfi/ayu)
 .hljs-strong {
   font-weight: bold;
 }
+
+.hljs-addition {
+  color: #91b362;
+}
+
+.hljs-deletion {
+  color: #d96c75;
+}

--- a/src/theme/highlight.css
+++ b/src/theme/highlight.css
@@ -67,3 +67,13 @@
 .hljs-strong {
   font-weight: bold;
 }
+
+.hljs-addition {
+  color: #22863a;
+  background-color: #f0fff4;
+}
+
+.hljs-deletion {
+  color: #b31d28;
+  background-color: #ffeef0;
+}

--- a/src/theme/tomorrow-night.css
+++ b/src/theme/tomorrow-night.css
@@ -94,3 +94,11 @@
 .xml .hljs-cdata {
   opacity: 0.5;
 }
+
+.hljs-addition {
+  color: #718c00;
+}
+
+.hljs-deletion {
+  color: #c82829;
+}


### PR DESCRIPTION
This adds the rules to highlight diff lines with highlight.js.

<img width="280" alt="image" src="https://user-images.githubusercontent.com/43198/58645480-4d100680-82b8-11e9-83cd-23d41b63ccd2.png">

<img width="284" alt="image" src="https://user-images.githubusercontent.com/43198/58645512-5c8f4f80-82b8-11e9-8cb1-45fcb8890f74.png">

<img width="286" alt="image" src="https://user-images.githubusercontent.com/43198/58645532-64e78a80-82b8-11e9-8737-0823042471bb.png">



Closes #927