### PR TITLE
Header elements wrap links

### DIFF
--- a/src/renderer/html_handlebars/hbs_renderer.rs
+++ b/src/renderer/html_handlebars/hbs_renderer.rs
@@ -508,14 +508,14 @@ fn build_header_links(html: &str) -> String {
                 .parse()
                 .expect("Regex should ensure we only ever get numbers here");
 
-            wrap_header_with_link(level, &caps[2], &mut id_counter)
+            insert_link_into_header(level, &caps[2], &mut id_counter)
         })
         .into_owned()
 }
 
 /// Wraps a single header tag with a link, making sure each tag gets its own
 /// unique ID by appending an auto-incremented number (if necessary).
-fn wrap_header_with_link(
+fn insert_link_into_header(
     level: usize,
     content: &str,
     id_counter: &mut HashMap<String, usize>,
@@ -532,7 +532,7 @@ fn wrap_header_with_link(
     *id_count += 1;
 
     format!(
-        r##"<a class="header" href="#{id}" id="{id}"><h{level}>{text}</h{level}></a>"##,
+        r##"<h{level}><a class="header" href="#{id}" id="{id}">{text}</a></h{level}>"##,
         level = level,
         id = id,
         text = content
@@ -640,27 +640,27 @@ mod tests {
         let inputs = vec![
             (
                 "blah blah <h1>Foo</h1>",
-                r##"blah blah <a class="header" href="#foo" id="foo"><h1>Foo</h1></a>"##,
+                r##"blah blah <h1><a class="header" href="#foo" id="foo">Foo</a></h1>"##,
             ),
             (
                 "<h1>Foo</h1>",
-                r##"<a class="header" href="#foo" id="foo"><h1>Foo</h1></a>"##,
+                r##"<h1><a class="header" href="#foo" id="foo">Foo</a></h1>"##,
             ),
             (
                 "<h3>Foo^bar</h3>",
-                r##"<a class="header" href="#foobar" id="foobar"><h3>Foo^bar</h3></a>"##,
+                r##"<h3><a class="header" href="#foobar" id="foobar">Foo^bar</a></h3>"##,
             ),
             (
                 "<h4></h4>",
-                r##"<a class="header" href="#" id=""><h4></h4></a>"##,
+                r##"<h4><a class="header" href="#" id=""></a></h4>"##,
             ),
             (
                 "<h4><em>Hï</em></h4>",
-                r##"<a class="header" href="#hï" id="hï"><h4><em>Hï</em></h4></a>"##,
+                r##"<h4><a class="header" href="#hï" id="hï"><em>Hï</em></a></h4>"##,
             ),
             (
                 "<h1>Foo</h1><h3>Foo</h3>",
-                r##"<a class="header" href="#foo" id="foo"><h1>Foo</h1></a><a class="header" href="#foo-1" id="foo-1"><h3>Foo</h3></a>"##,
+                r##"<h1><a class="header" href="#foo" id="foo">Foo</a></h1><h3><a class="header" href="#foo-1" id="foo-1">Foo</a></h3>"##,
             ),
         ];
 

--- a/src/renderer/html_handlebars/hbs_renderer.rs
+++ b/src/renderer/html_handlebars/hbs_renderer.rs
@@ -496,8 +496,8 @@ fn make_data(
     Ok(data)
 }
 
-/// Goes through the rendered HTML, making sure all header tags are wrapped in
-/// an anchor so people can link to sections directly.
+/// Goes through the rendered HTML, making sure all header tags have
+/// an anchor respectively so people can link to sections directly.
 fn build_header_links(html: &str) -> String {
     let regex = Regex::new(r"<h(\d)>(.*?)</h\d>").unwrap();
     let mut id_counter = HashMap::new();
@@ -513,7 +513,7 @@ fn build_header_links(html: &str) -> String {
         .into_owned()
 }
 
-/// Wraps a single header tag with a link, making sure each tag gets its own
+/// Insert a sinle link into a header, making sure each link gets its own
 /// unique ID by appending an auto-incremented number (if necessary).
 fn insert_link_into_header(
     level: usize,

--- a/src/theme/css/general.css
+++ b/src/theme/css/general.css
@@ -34,10 +34,10 @@ h4, h5 { margin-top: 2em; }
     margin-top: 1em;
 }
 
-a.header:target h1:before,
-a.header:target h2:before,
-a.header:target h3:before,
-a.header:target h4:before {
+h1 a.header:target::before,
+h2 a.header:target::before,
+h3 a.header:target::before,
+h4 a.header:target::before {
     display: inline-block;
     content: "»";
     margin-left: -30px;

--- a/tests/rendered_output.rs
+++ b/tests/rendered_output.rs
@@ -327,7 +327,10 @@ fn able_to_include_files_in_chapters() {
 
     let includes = temp.path().join("book/first/includes.html");
 
-    let summary_strings = &["<h1>Summary</h1>", ">First Chapter</a>"];
+    let summary_strings = &[
+        r##"<h1><a class="header" href="#summary" id="summary">Summary</a></h1>"##,
+        ">First Chapter</a>",
+    ];
     assert_contains_strings(&includes, summary_strings);
 
     assert_doesnt_contain_strings(&includes, &["{{#include ../SUMMARY.md::}}"]);


### PR DESCRIPTION
Fixes #896

now: 
> ![Jun-03-2019 15-48-34](https://user-images.githubusercontent.com/31783570/58781553-2f73d180-8617-11e9-997b-c32126634299.gif)

with this change:
> ![Jun-03-2019 15-48-58](https://user-images.githubusercontent.com/31783570/58781558-339fef00-8617-11e9-9c73-cb1f4f7b4698.gif)
