### PR TITLE
Update specified minimum Rust version and test it in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,8 @@ matrix:
       env: TARGET=x86_64-unknown-linux-gnu
     - rust: nightly
       env: TARGET=x86_64-unknown-linux-gnu
+    - rust: 1.34.0 # Minimum required Rust version
+      env: TARGET=x86_64-unknown-linux-gnu
 
     - rust: stable
       os: osx

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ There are multiple ways to install mdBook.
 
 2. **From Crates.io**
 
-   This requires at least [Rust] 1.20 and Cargo to be installed. Once you have installed
+   This requires at least [Rust] 1.34 and Cargo to be installed. Once you have installed
    Rust, type the following in the terminal:
 
    ```


### PR DESCRIPTION
I did some research by running the tests in travis with different Rust versions, and the first Rust version to successfully build mdbook commit 69a08ef390750d3cdbcdf807f505e559eb6418c6 (v0.3.0) is 1.34 because pulldown-cmark 0.5.2 uses try_from.

Here are the two builds where I was testing different versions:

- https://travis-ci.com/integer32llc/mdBook/builds/116221517
- https://travis-ci.com/integer32llc/mdBook/builds/116287470

I also added 1.34 to the Travis build matrix so that we'll know sooner when a change bumps the minimum.

Our community surveys have shown the vast majority of Rust users are on the latest stable, so I think supporting one stable back is plenty.