### PR TITLE
Switch to the standard library's fs::read_to_string

### DIFF
--- a/src/preprocess/links.rs
+++ b/src/preprocess/links.rs
@@ -1,7 +1,7 @@
 use crate::errors::*;
-use crate::utils::fs::file_to_string;
 use crate::utils::take_lines;
 use regex::{CaptureMatches, Captures, Regex};
+use std::fs;
 use std::ops::{Range, RangeFrom, RangeFull, RangeTo};
 use std::path::{Path, PathBuf};
 
@@ -211,7 +211,7 @@ impl<'a> Link<'a> {
             LinkType::IncludeRange(ref pat, ref range) => {
                 let target = base.join(pat);
 
-                file_to_string(&target)
+                fs::read_to_string(&target)
                     .map(|s| take_lines(&s, range.clone()))
                     .chain_err(|| {
                         format!(
@@ -224,7 +224,7 @@ impl<'a> Link<'a> {
             LinkType::IncludeRangeFrom(ref pat, ref range) => {
                 let target = base.join(pat);
 
-                file_to_string(&target)
+                fs::read_to_string(&target)
                     .map(|s| take_lines(&s, range.clone()))
                     .chain_err(|| {
                         format!(
@@ -237,7 +237,7 @@ impl<'a> Link<'a> {
             LinkType::IncludeRangeTo(ref pat, ref range) => {
                 let target = base.join(pat);
 
-                file_to_string(&target)
+                fs::read_to_string(&target)
                     .map(|s| take_lines(&s, *range))
                     .chain_err(|| {
                         format!(
@@ -250,7 +250,7 @@ impl<'a> Link<'a> {
             LinkType::IncludeRangeFull(ref pat, _) => {
                 let target = base.join(pat);
 
-                file_to_string(&target).chain_err(|| {
+                fs::read_to_string(&target).chain_err(|| {
                     format!(
                         "Could not read file for link {} ({})",
                         self.link_text,
@@ -261,7 +261,7 @@ impl<'a> Link<'a> {
             LinkType::Playpen(ref pat, ref attrs) => {
                 let target = base.join(pat);
 
-                let contents = file_to_string(&target).chain_err(|| {
+                let contents = fs::read_to_string(&target).chain_err(|| {
                     format!(
                         "Could not read file for link {} ({})",
                         self.link_text,

--- a/src/utils/fs.rs
+++ b/src/utils/fs.rs
@@ -1,21 +1,8 @@
 use crate::errors::*;
 use std::convert::Into;
 use std::fs::{self, File};
-use std::io::{Read, Write};
+use std::io::Write;
 use std::path::{Component, Path, PathBuf};
-
-/// Takes a path to a file and try to read the file into a String
-pub fn file_to_string<P: AsRef<Path>>(path: P) -> Result<String> {
-    let path = path.as_ref();
-
-    let mut content = String::new();
-    File::open(path)
-        .chain_err(|| "Unable to open the file")?
-        .read_to_string(&mut content)
-        .chain_err(|| "Unable to read the file")?;
-
-    Ok(content)
-}
 
 /// Naively replaces any path seperator with a forward-slash '/'
 pub fn normalize_path(path: &str) -> String {

--- a/tests/dummy_book/mod.rs
+++ b/tests/dummy_book/mod.rs
@@ -5,7 +5,6 @@
 #![allow(dead_code, unused_variables, unused_imports, unused_extern_crates)]
 
 use mdbook::errors::*;
-use mdbook::utils::fs::file_to_string;
 use std::fs::{self, File};
 use std::io::{Read, Write};
 use std::path::Path;
@@ -64,7 +63,7 @@ impl DummyBook {
 }
 
 fn replace_pattern_in_file(filename: &Path, from: &str, to: &str) -> Result<()> {
-    let contents = file_to_string(filename)?;
+    let contents = fs::read_to_string(filename)?;
     File::create(filename)?.write_all(contents.replace(from, to).as_bytes())?;
 
     Ok(())
@@ -74,7 +73,7 @@ fn replace_pattern_in_file(filename: &Path, from: &str, to: &str) -> Result<()> 
 /// the list of strings asserting that the file contains all of them.
 pub fn assert_contains_strings<P: AsRef<Path>>(filename: P, strings: &[&str]) {
     let filename = filename.as_ref();
-    let content = file_to_string(filename).expect("Couldn't read the file's contents");
+    let content = fs::read_to_string(filename).expect("Couldn't read the file's contents");
 
     for s in strings {
         assert!(
@@ -89,7 +88,7 @@ pub fn assert_contains_strings<P: AsRef<Path>>(filename: P, strings: &[&str]) {
 
 pub fn assert_doesnt_contain_strings<P: AsRef<Path>>(filename: P, strings: &[&str]) {
     let filename = filename.as_ref();
-    let content = file_to_string(filename).expect("Couldn't read the file's contents");
+    let content = fs::read_to_string(filename).expect("Couldn't read the file's contents");
 
     for s in strings {
         assert!(

--- a/tests/rendered_output.rs
+++ b/tests/rendered_output.rs
@@ -7,7 +7,7 @@ use crate::dummy_book::{assert_contains_strings, assert_doesnt_contain_strings, 
 
 use mdbook::config::Config;
 use mdbook::errors::*;
-use mdbook::utils::fs::{file_to_string, write_file};
+use mdbook::utils::fs::write_file;
 use mdbook::MDBook;
 use select::document::Document;
 use select::predicate::{Class, Name, Predicate};
@@ -220,7 +220,7 @@ fn root_index_html() -> Result<Document> {
         .chain_err(|| "Book building failed")?;
 
     let index_page = temp.path().join("book").join("index.html");
-    let html = file_to_string(&index_page).chain_err(|| "Unable to read index.html")?;
+    let html = fs::read_to_string(&index_page).chain_err(|| "Unable to read index.html")?;
 
     Ok(Document::from(html.as_str()))
 }
@@ -468,14 +468,13 @@ fn markdown_options() {
 #[cfg(feature = "search")]
 mod search {
     use crate::dummy_book::DummyBook;
-    use mdbook::utils::fs::file_to_string;
     use mdbook::MDBook;
-    use std::fs::File;
+    use std::fs::{self, File};
     use std::path::Path;
 
     fn read_book_index(root: &Path) -> serde_json::Value {
         let index = root.join("book/searchindex.js");
-        let index = file_to_string(index).unwrap();
+        let index = fs::read_to_string(index).unwrap();
         let index = index.trim_start_matches("Object.assign(window.search, ");
         let index = index.trim_end_matches(");");
         serde_json::from_str(&index).unwrap()


### PR DESCRIPTION
It was stabilized in 1.26, which is fine [because the current required Rust version is 1.34](https://github.com/rust-lang-nursery/mdBook/pull/960).