### PR TITLE
Use stdlib RangeBounds

### DIFF
--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -9,7 +9,7 @@ use pulldown_cmark::{html, CowStr, Event, Options, Parser, Tag};
 
 use std::borrow::Cow;
 
-pub use self::string::{take_lines, RangeArgument};
+pub use self::string::take_lines;
 
 /// Replaces multiple consecutive whitespace characters with a single space character.
 pub fn collapse_whitespace(text: &str) -> Cow<'_, str> {


### PR DESCRIPTION
Found this TODO; `RangeBounds` was stabilized in 1.28, so this is fine [because the current required Rust version is 1.34](https://github.com/rust-lang-nursery/mdBook/pull/960).