### PR TITLE
Don't keep gh-pages history.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -69,7 +69,7 @@ deploy:
   local_dir: book-example/book
   skip_cleanup: true
   github_token: "$GITHUB_TOKEN"
-  keep_history: true
+  keep_history: false
   on:
     condition: $TRAVIS_OS_NAME = "linux" && $TRAVIS_RUST_VERSION = "stable"
     tags: true


### PR DESCRIPTION
This changes it so that Travis will squash the gh-pages branch each time a new release is done. The git repo is quite large (~100MB), and the hope is that this will significantly shrink it.  I don't think there is any real reason to keep the history, since it is generated from the source, and the history for that still exists.