### PR TITLE
Allow backends to cache previous results

### DIFF
--- a/book-example/src/for_developers/backends.md
+++ b/book-example/src/for_developers/backends.md
@@ -261,6 +261,10 @@ in [`RenderContext`].
 > **Note:** There is no guarantee that the destination directory exists or is
 > empty (`mdbook` may leave the previous contents to let backends do caching),
 > so it's always a good idea to create it with `fs::create_dir_all()`.
+>
+> If the destination directory already exists, don't assume it will be empty.
+> To allow backends to cache the results from previous runs, `mdbook` may leave
+> old content in the directory.
 
 There's always the possibility that an error will occur while processing a book
 (just look at all the `unwrap()`'s we've written already), so `mdbook` will

--- a/src/book/mod.rs
+++ b/src/book/mod.rs
@@ -190,9 +190,6 @@ impl MDBook {
             renderer.name().to_string(),
         );
 
-        let name = renderer.name();
-        let build_dir = self.build_dir_for(name);
-
         for preprocessor in &self.preprocessors {
             if preprocessor_should_run(&**preprocessor, renderer, &self.config) {
                 debug!("Running the {} preprocessor.", preprocessor.name());

--- a/src/book/mod.rs
+++ b/src/book/mod.rs
@@ -192,16 +192,6 @@ impl MDBook {
 
         let name = renderer.name();
         let build_dir = self.build_dir_for(name);
-        if build_dir.exists() {
-            debug!(
-                "Cleaning build dir for the \"{}\" renderer ({})",
-                name,
-                build_dir.display()
-            );
-
-            utils::fs::remove_dir_content(&build_dir)
-                .chain_err(|| "Unable to clear output directory")?;
-        }
 
         for preprocessor in &self.preprocessors {
             if preprocessor_should_run(&**preprocessor, renderer, &self.config) {

--- a/src/renderer/html_handlebars/hbs_renderer.rs
+++ b/src/renderer/html_handlebars/hbs_renderer.rs
@@ -282,6 +282,9 @@ impl Renderer for HtmlHandlebars {
         let destination = &ctx.destination;
         let book = &ctx.book;
 
+        utils::remove_dir_contents(destination)
+            .chain_err(|| "Unable to remove stale HTML output")?
+
         trace!("render");
         let mut handlebars = Handlebars::new();
 

--- a/src/renderer/html_handlebars/hbs_renderer.rs
+++ b/src/renderer/html_handlebars/hbs_renderer.rs
@@ -282,8 +282,10 @@ impl Renderer for HtmlHandlebars {
         let destination = &ctx.destination;
         let book = &ctx.book;
 
-        utils::remove_dir_contents(destination)
-            .chain_err(|| "Unable to remove stale HTML output")?
+        if destination.exists() {
+            utils::fs::remove_dir_content(destination)
+                .chain_err(|| "Unable to remove stale HTML output")?;
+        }
 
         trace!("render");
         let mut handlebars = Handlebars::new();


### PR DESCRIPTION
This is something that came up in my rewrite of `mdbook-linkcheck` (https://github.com/Michael-F-Bryan/mdbook-linkcheck/pull/11). I'd implemented a cache so we don't execute lots of slow web requests too frequently, and found that the cache file didn't exist every time the `mdbook-linkcheck` backend was invoked.

We probably want to let backends cache previous results. This PR removes the call to `utils::fs::remove_dir_content(&build_dir)` in `MDBook::build()` and makes sure the the HTML renderer manually cleans its destination directory.

I've also updated the user-docs to mention this.