### PR TITLE
Add `--path .` to cargo install commands.

### DIFF
--- a/book-example/src/for_developers/backends.md
+++ b/book-example/src/for_developers/backends.md
@@ -93,7 +93,7 @@ Now we've got the basics running, we want to actually use it. First, install the
 program.
 
 ```shell
-$ cargo install
+$ cargo install --path .
 ```
 
 Then `cd` to the particular book you'd like to count the words of and update its
@@ -304,7 +304,7 @@ like this:
 Now, if we reinstall the backend and build a book,
 
 ```shell
-$ cargo install --force
+$ cargo install --path . --force
 $ mdbook build /path/to/book
 ...
 2018-01-16 21:21:39 [INFO] (mdbook::renderer): Invoking the "wordcount" renderer


### PR DESCRIPTION
Changing `cargo install` to `cargo install --path .` prevents the following error:

**error:** Using `cargo install` to install the binaries for the package in current working directory is no longer supported, use `cargo install --path .` instead. Use `cargo build` if you want to simply build the package.
