### PR TITLE
Refactoring of some functionality in links.rs

### DIFF
--- a/src/preprocess/links.rs
+++ b/src/preprocess/links.rs
@@ -187,12 +187,10 @@ fn parse_include_path(path: &str) -> LinkType<'static> {
     let start = if let Some(value) = next_element.and_then(|s| s.parse::<usize>().ok()) {
         // subtract 1 since line numbers usually begin with 1
         Some(value.saturating_sub(1))
+    } else if let Some("") = next_element {
+        None
     } else if let Some(anchor) = next_element {
-        if anchor == "" {
-            None
-        } else {
-            return LinkType::IncludeAnchor(path, String::from(anchor));
-        }
+        return LinkType::IncludeAnchor(path, String::from(anchor));
     } else {
         None
     };

--- a/src/preprocess/links.rs
+++ b/src/preprocess/links.rs
@@ -180,7 +180,7 @@ fn return_relative_path<P: AsRef<Path>>(base: P, relative: P) -> PathBuf {
 }
 
 fn parse_include_path(path: &str) -> LinkType<'static> {
-    let mut parts = path.split(':');
+    let mut parts = path.split(':').fuse();
     let path = parts.next().unwrap().into();
 
     let next_element = parts.next();

--- a/src/preprocess/links.rs
+++ b/src/preprocess/links.rs
@@ -180,7 +180,7 @@ fn return_relative_path<P: AsRef<Path>>(base: P, relative: P) -> PathBuf {
 }
 
 fn parse_include_path(path: &str) -> LinkType<'static> {
-    let mut parts = path.split(':').fuse();
+    let mut parts = path.splitn(4, ':').fuse();
     let path = parts.next().unwrap().into();
 
     let next_element = parts.next();

--- a/src/preprocess/links.rs
+++ b/src/preprocess/links.rs
@@ -198,24 +198,15 @@ fn parse_include_path(path: &str) -> LinkType<'static> {
     let end = parts.next();
     let has_end = end.is_some();
     let end = end.and_then(|s| s.parse::<usize>().ok());
-    match start {
-        Some(start) => match end {
-            Some(end) => LinkType::IncludeRange(path, LineRange::from(start..end)),
-            None => {
-                if has_end {
-                    LinkType::IncludeRange(path, LineRange::from(start..))
-                } else {
-                    LinkType::IncludeRange(
-                        path,
-                        LineRange::from(start..start + 1),
-                    )
-                }
-            }
-        },
-        None => match end {
-            Some(end) => LinkType::IncludeRange(path, LineRange::from(..end)),
-            None => LinkType::IncludeRange(path, LineRange::from(RangeFull)),
-        },
+
+    match (start, end, has_end) {
+        (Some(start), Some(end), _) => LinkType::IncludeRange(path, LineRange::from(start..end)),
+        (Some(start), None, true) => LinkType::IncludeRange(path, LineRange::from(start..)),
+        (Some(start), None, false) => {
+            LinkType::IncludeRange(path, LineRange::from(start..start + 1))
+        }
+        (None, Some(end), _) => LinkType::IncludeRange(path, LineRange::from(..end)),
+        (None, None, _) => LinkType::IncludeRange(path, LineRange::from(RangeFull)),
     }
 }
 


### PR DESCRIPTION
Hi, I have a new feature I'm working on that I could really use for the book (https://github.com/rust-lang-nursery/mdBook/issues/618), but these refactorings make it easier. I decided to submit these first separately from the new feature, to get feedback before basing the new feature on this.

There are 2 big chunks of refactorings in this PR, and I'm happy to split them into 2 PRs if anyone wants:

- The first commit extracts a data structure to hold the different kind of ranges, so that different kinds of file including mechanisms can use the same data structure. This reduces some kinds of repetition, but adds a bit more boilerplate.
- The rest of the commits improve the `parse_include_path` function: I think I've gotten test coverage around all the branches, and I think I've improved the code while keeping those tests passing. I think the code is clearer now, but it's certainly debatable, so I'd love to hear any thoughts.

Thanks! ❤️ 	