### PR TITLE
When this test fails, print out why to assist in debugging

### DIFF
--- a/tests/testing.rs
+++ b/tests/testing.rs
@@ -9,7 +9,12 @@ fn mdbook_can_correctly_test_a_passing_book() {
     let temp = DummyBook::new().with_passing_test(true).build().unwrap();
     let mut md = MDBook::load(temp.path()).unwrap();
 
-    assert!(md.test(vec![]).is_ok());
+    let result = md.test(vec![]);
+    assert!(
+        result.is_ok(),
+        "Tests failed with {}",
+        result.err().unwrap()
+    );
 }
 
 #[test]


### PR DESCRIPTION
I break this test often as I'm working on mdBook, and its output isn't very forthcoming with an explanation about why it failed.

With this change, when this test fails, it'll print out the error message that `mdbook` prints when `mdbook test` fails. TESTS ALL THE WAY DOWN!!

Output before this change if this test fails (I broke `include` on purpose to illustrate a failure):

```
$ cargo test --test testing
    Finished dev [unoptimized + debuginfo] target(s) in 0.11s
     Running target/debug/deps/testing-c42aba08d8f4704b

running 2 tests
test mdbook_can_correctly_test_a_passing_book ... FAILED
test mdbook_detects_book_with_failing_tests ... ok

failures:

---- mdbook_can_correctly_test_a_passing_book stdout ----
thread 'mdbook_can_correctly_test_a_passing_book' panicked at 'assertion failed: md.test(vec![]).is_ok()', tests/testing.rs:12:5
note: Run with `RUST_BACKTRACE=1` environment variable to display a backtrace.
```

Output after this change:

```
 $ cargo test --test testing
   Compiling mdbook v0.3.1 (/Users/carolnichols/rust/mdBook)
    Finished dev [unoptimized + debuginfo] target(s) in 3.30s
     Running target/debug/deps/testing-c42aba08d8f4704b

running 2 tests
test mdbook_detects_book_with_failing_tests ... ok
test mdbook_can_correctly_test_a_passing_book ... FAILED

failures:

---- mdbook_can_correctly_test_a_passing_book stdout ----
thread 'mdbook_can_correctly_test_a_passing_book' panicked at 'Tests failed with Rustdoc returned an error:
running 2 tests
test /var/folders/qc/0ry2bjtd7wd9q8r1c7wylplr0000gn/T/mdbook-u9qeXX/first/nested.md - Nested_Chapter::Some_Section (line 11) ... FAILED
test /var/folders/qc/0ry2bjtd7wd9q8r1c7wylplr0000gn/T/mdbook-u9qeXX/first/nested.md - Nested_Chapter (line 5) ... ok

failures:

---- /var/folders/qc/0ry2bjtd7wd9q8r1c7wylplr0000gn/T/mdbook-u9qeXX/first/nested.md - Nested_Chapter::Some_Section (line 11) stdout ----
error: expected `[`, found `include`
 --> /var/folders/qc/0ry2bjtd7wd9q8r1c7wylplr0000gn/T/mdbook-u9qeXX/first/nested.md:12:4
  |
3 | {{#include nested-test.rs}}
  |    ^^^^^^^ expected `[`

error: aborting due to previous error

thread '/var/folders/qc/0ry2bjtd7wd9q8r1c7wylplr0000gn/T/mdbook-u9qeXX/first/nested.md - Nested_Chapter::Some_Section (line 11)' panicked at 'couldn't compile the test', src/librustdoc/test.rs:319:13
note: Run with `RUST_BACKTRACE=1` environment variable to display a backtrace.
```