### PR TITLE
Implement a `rustdoc_include` preprocessor

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ matrix:
       env: TARGET=x86_64-unknown-linux-gnu
     - rust: nightly
       env: TARGET=x86_64-unknown-linux-gnu
-    - rust: 1.34.0 # Minimum required Rust version
+    - rust: 1.35.0 # Minimum required Rust version
       env: TARGET=x86_64-unknown-linux-gnu
 
     - rust: stable

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ There are multiple ways to install mdBook.
 
 2. **From Crates.io**
 
-   This requires at least [Rust] 1.34 and Cargo to be installed. Once you have installed
+   This requires at least [Rust] 1.35 and Cargo to be installed. Once you have installed
    Rust, type the following in the terminal:
 
    ```

--- a/book-example/src/format/config.md
+++ b/book-example/src/format/config.md
@@ -81,7 +81,7 @@ This controls the build process of your book.
 
 The following preprocessors are available and included by default:
 
-- `links`: Expand the `{{ #playpen }}` and `{{ #include }}` handlebars
+- `links`: Expand the `{{ #playpen }}`, `{{ #include }}`, and `{{ #rustdoc_include }}` handlebars
   helpers in a chapter to include the contents of a file.
 - `index`: Convert all chapter files named `README.md` into `index.md`. That is
   to say, all `README.md` would be rendered to an index file `index.html` in the

--- a/book-example/src/format/mdbook.md
+++ b/book-example/src/format/mdbook.md
@@ -3,7 +3,9 @@
 ## Hiding code lines
 
 There is a feature in mdBook that lets you hide code lines by prepending them
-with a `#`.
+with a `#` [in the same way that Rustdoc does][rustdoc-hide].
+
+[rustdoc-hide]: https://doc.rust-lang.org/stable/rustdoc/documentation-tests.html#hiding-portions-of-the-example
 
 ```bash
 # fn main() {
@@ -106,6 +108,70 @@ This is the full file.
 ````
 
 Lines containing anchor patterns inside the included anchor are ignored.
+
+## Including a file but initially hiding all except specified lines
+
+The `rustdoc_include` helper is for including code from external Rust files that contain complete
+examples, but only initially showing particular lines specified with line numbers or anchors in the
+same way as with `include`.
+
+The lines not in the line number range or between the anchors will still be included, but they will
+be prefaced with `#`. This way, a reader can expand the snippet to see the complete example, and
+Rustdoc will use the complete example when you run `mdbook test`.
+
+For example, consider a file named `file.rs` that contains this Rust program:
+
+```rust
+fn main() {
+    let x = add_one(2);
+    assert_eq!(x, 3);
+}
+
+fn add_one(num: i32) -> i32 {
+    num + 1
+}
+```
+
+We can include a snippet that initially shows only line 2 by using this syntax:
+
+````hbs
+To call the `add_one` function, we pass it an `i32` and bind the returned value to `x`:
+
+```rust
+\{{#rustdoc_include file.rs:2}}
+```
+````
+
+This would have the same effect as if we had manually inserted the code and hidden all but line 2
+using `#`:
+
+````hbs
+To call the `add_one` function, we pass it an `i32` and bind the returned value to `x`:
+
+```rust
+# fn main() {
+    let x = add_one(2);
+#     assert_eq!(x, 3);
+# }
+#
+# fn add_one(num: i32) -> i32 {
+#     num + 1
+#}
+```
+````
+
+That is, it looks like this (click the "expand" icon to see the rest of the file):
+
+```rust
+# fn main() {
+    let x = add_one(2);
+#     assert_eq!(x, 3);
+# }
+#
+# fn add_one(num: i32) -> i32 {
+#     num + 1
+#}
+```
 
 ## Inserting runnable Rust files
 

--- a/src/preprocess/links.rs
+++ b/src/preprocess/links.rs
@@ -1,5 +1,8 @@
 use crate::errors::*;
-use crate::utils::{take_anchored_lines, take_lines};
+use crate::utils::{
+    take_anchored_lines, take_lines, take_rustdoc_include_anchored_lines,
+    take_rustdoc_include_lines,
+};
 use regex::{CaptureMatches, Captures, Regex};
 use std::fs;
 use std::ops::{Bound, Range, RangeBounds, RangeFrom, RangeFull, RangeTo};
@@ -11,8 +14,15 @@ use crate::book::{Book, BookItem};
 const ESCAPE_CHAR: char = '\\';
 const MAX_LINK_NESTED_DEPTH: usize = 10;
 
-/// A preprocessor for expanding the `{{# playpen}}` and `{{# include}}`
-/// helpers in a chapter.
+/// A preprocessor for expanding helpers in a chapter. Supported helpers are:
+///
+/// - `{{# include}}` - Insert an external file of any type. Include the whole file, only particular
+///.  lines, or only between the specified anchors.
+/// - `{{# rustdoc_include}}` - Insert an external Rust file, showing the particular lines
+///.  specified or the lines between specified anchors, and include the rest of the file behind `#`.
+///   This hides the lines from initial display but shows them when the reader expands the code
+///   block and provides them to Rustdoc for testing.
+/// - `{{# playpen}}` - Insert runnable Rust files
 #[derive(Default)]
 pub struct LinkPreprocessor;
 
@@ -104,6 +114,7 @@ enum LinkType<'a> {
     Escaped,
     Include(PathBuf, RangeOrAnchor),
     Playpen(PathBuf, Vec<&'a str>),
+    RustdocInclude(PathBuf, RangeOrAnchor),
 }
 
 #[derive(PartialEq, Debug, Clone)]
@@ -172,6 +183,7 @@ impl<'a> LinkType<'a> {
             LinkType::Escaped => None,
             LinkType::Include(p, _) => Some(return_relative_path(base, &p)),
             LinkType::Playpen(p, _) => Some(return_relative_path(base, &p)),
+            LinkType::RustdocInclude(p, _) => Some(return_relative_path(base, &p)),
         }
     }
 }
@@ -222,6 +234,15 @@ fn parse_include_path(path: &str) -> LinkType<'static> {
     LinkType::Include(path, range_or_anchor)
 }
 
+fn parse_rustdoc_include_path(path: &str) -> LinkType<'static> {
+    let mut parts = path.splitn(2, ':');
+
+    let path = parts.next().unwrap().into();
+    let range_or_anchor = parse_range_or_anchor(parts.next());
+
+    LinkType::RustdocInclude(path, range_or_anchor)
+}
+
 #[derive(PartialEq, Debug, Clone)]
 struct Link<'a> {
     start_index: usize,
@@ -241,6 +262,7 @@ impl<'a> Link<'a> {
                 match (typ.as_str(), file_arg) {
                     ("include", Some(pth)) => Some(parse_include_path(pth)),
                     ("playpen", Some(pth)) => Some(LinkType::Playpen(pth.into(), props)),
+                    ("rustdoc_include", Some(pth)) => Some(parse_rustdoc_include_path(pth)),
                     _ => None,
                 }
             }
@@ -272,6 +294,26 @@ impl<'a> Link<'a> {
                     .map(|s| match range_or_anchor {
                         RangeOrAnchor::Range(range) => take_lines(&s, range.clone()),
                         RangeOrAnchor::Anchor(anchor) => take_anchored_lines(&s, anchor),
+                    })
+                    .chain_err(|| {
+                        format!(
+                            "Could not read file for link {} ({})",
+                            self.link_text,
+                            target.display(),
+                        )
+                    })
+            }
+            LinkType::RustdocInclude(ref pat, ref range_or_anchor) => {
+                let target = base.join(pat);
+
+                fs::read_to_string(&target)
+                    .map(|s| match range_or_anchor {
+                        RangeOrAnchor::Range(range) => {
+                            take_rustdoc_include_lines(&s, range.clone())
+                        }
+                        RangeOrAnchor::Anchor(anchor) => {
+                            take_rustdoc_include_anchored_lines(&s, anchor)
+                        }
                     })
                     .chain_err(|| {
                         format!(

--- a/src/preprocess/links.rs
+++ b/src/preprocess/links.rs
@@ -326,7 +326,7 @@ fn find_links(contents: &str) -> LinkIter<'_> {
             \\\{\{\#.*\}\}             # match escaped link
             |                          # or
             \{\{\s*                    # link opening parens and whitespace
-            \#([a-zA-Z0-9]+)           # link type
+            \#([a-zA-Z0-9_]+)          # link type
             \s+                        # separating whitespace
             ([a-zA-Z0-9\s_.\-:/\\]+)   # link target path and space separated properties
             \s*\}\}                    # whitespace and link closing parens"

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -11,7 +11,10 @@ use std::borrow::Cow;
 use std::fmt::Write;
 use std::path::Path;
 
-pub use self::string::{take_anchored_lines, take_lines};
+pub use self::string::{
+    take_anchored_lines, take_lines, take_rustdoc_include_anchored_lines,
+    take_rustdoc_include_lines,
+};
 
 /// Replaces multiple consecutive whitespace characters with a single space character.
 pub fn collapse_whitespace(text: &str) -> Cow<'_, str> {

--- a/src/utils/string.rs
+++ b/src/utils/string.rs
@@ -242,5 +242,11 @@ mod tests {
             take_rustdoc_include_anchored_lines(s, "something"),
             "# Lorem\n# ipsum\n# dolor\n# sit\n# amet\n# lorem\n# ipsum"
         );
+
+        let s = "Lorem\nANCHOR: test\nipsum\nANCHOR_END: test\ndolor\nANCHOR: test\nsit\nANCHOR_END: test\namet";
+        assert_eq!(
+            take_rustdoc_include_anchored_lines(s, "test"),
+            "# Lorem\nipsum\n# dolor\nsit\n# amet"
+        );
     }
 }

--- a/src/utils/string.rs
+++ b/src/utils/string.rs
@@ -18,33 +18,33 @@ pub fn take_lines<R: RangeBounds<usize>>(s: &str, range: R) -> String {
     }
 }
 
+lazy_static! {
+    static ref ANCHOR_START: Regex = Regex::new(r"ANCHOR:\s*(?P<anchor_name>[\w_-]+)").unwrap();
+    static ref ANCHOR_END: Regex = Regex::new(r"ANCHOR_END:\s*(?P<anchor_name>[\w_-]+)").unwrap();
+}
+
 /// Take anchored lines from a string.
 /// Lines containing anchor are ignored.
 pub fn take_anchored_lines(s: &str, anchor: &str) -> String {
-    lazy_static! {
-        static ref RE_START: Regex = Regex::new(r"ANCHOR:\s*(?P<anchor_name>[\w_-]+)").unwrap();
-        static ref RE_END: Regex = Regex::new(r"ANCHOR_END:\s*(?P<anchor_name>[\w_-]+)").unwrap();
-    }
-
     let mut retained = Vec::<&str>::new();
     let mut anchor_found = false;
 
     for l in s.lines() {
         if anchor_found {
-            match RE_END.captures(l) {
+            match ANCHOR_END.captures(l) {
                 Some(cap) => {
                     if &cap["anchor_name"] == anchor {
                         break;
                     }
                 }
                 None => {
-                    if !RE_START.is_match(l) {
+                    if !ANCHOR_START.is_match(l) {
                         retained.push(l);
                     }
                 }
             }
         } else {
-            if let Some(cap) = RE_START.captures(l) {
+            if let Some(cap) = ANCHOR_START.captures(l) {
                 if &cap["anchor_name"] == anchor {
                     anchor_found = true;
                 }
@@ -55,9 +55,70 @@ pub fn take_anchored_lines(s: &str, anchor: &str) -> String {
     retained.join("\n")
 }
 
+/// Keep lines contained within the range specified as-is.
+/// For any lines not in the range, include them but use `#` at the beginning. This will hide the
+/// lines from initial display but include them when expanding the code snippet or testing with
+/// rustdoc.
+pub fn take_rustdoc_include_lines<R: RangeBounds<usize>>(s: &str, range: R) -> String {
+    let mut output = String::with_capacity(s.len());
+
+    for (index, line) in s.lines().enumerate() {
+        if !range.contains(&index) {
+            output.push_str("# ");
+        }
+        output.push_str(line);
+        output.push_str("\n");
+    }
+    output.pop();
+    output
+}
+
+/// Keep lines between the anchor comments specified as-is.
+/// For any lines not between the anchors, include them but use `#` at the beginning. This will
+/// hide the lines from initial display but include them when expanding the code snippet or testing
+/// with rustdoc.
+pub fn take_rustdoc_include_anchored_lines(s: &str, anchor: &str) -> String {
+    let mut output = String::with_capacity(s.len());
+    let mut within_anchored_section = false;
+
+    for l in s.lines() {
+        if within_anchored_section {
+            match ANCHOR_END.captures(l) {
+                Some(cap) => {
+                    if &cap["anchor_name"] == anchor {
+                        within_anchored_section = false;
+                    }
+                }
+                None => {
+                    if !ANCHOR_START.is_match(l) {
+                        output.push_str(l);
+                        output.push_str("\n");
+                    }
+                }
+            }
+        } else {
+            if let Some(cap) = ANCHOR_START.captures(l) {
+                if &cap["anchor_name"] == anchor {
+                    within_anchored_section = true;
+                }
+            } else if !ANCHOR_END.is_match(l) {
+                output.push_str("# ");
+                output.push_str(l);
+                output.push_str("\n");
+            }
+        }
+    }
+
+    output.pop();
+    output
+}
+
 #[cfg(test)]
 mod tests {
-    use super::{take_anchored_lines, take_lines};
+    use super::{
+        take_anchored_lines, take_lines, take_rustdoc_include_anchored_lines,
+        take_rustdoc_include_lines,
+    };
 
     #[test]
     fn take_lines_test() {
@@ -98,5 +159,88 @@ mod tests {
         );
         assert_eq!(take_anchored_lines(s, "test"), "dolor\nsit\namet");
         assert_eq!(take_anchored_lines(s, "something"), "");
+    }
+
+    #[test]
+    fn take_rustdoc_include_lines_test() {
+        let s = "Lorem\nipsum\ndolor\nsit\namet";
+        assert_eq!(
+            take_rustdoc_include_lines(s, 1..3),
+            "# Lorem\nipsum\ndolor\n# sit\n# amet"
+        );
+        assert_eq!(
+            take_rustdoc_include_lines(s, 3..),
+            "# Lorem\n# ipsum\n# dolor\nsit\namet"
+        );
+        assert_eq!(
+            take_rustdoc_include_lines(s, ..3),
+            "Lorem\nipsum\ndolor\n# sit\n# amet"
+        );
+        assert_eq!(take_rustdoc_include_lines(s, ..), s);
+        // corner cases
+        assert_eq!(
+            take_rustdoc_include_lines(s, 4..3),
+            "# Lorem\n# ipsum\n# dolor\n# sit\n# amet"
+        );
+        assert_eq!(take_rustdoc_include_lines(s, ..100), s);
+    }
+
+    #[test]
+    fn take_rustdoc_include_anchored_lines_test() {
+        let s = "Lorem\nipsum\ndolor\nsit\namet";
+        assert_eq!(
+            take_rustdoc_include_anchored_lines(s, "test"),
+            "# Lorem\n# ipsum\n# dolor\n# sit\n# amet"
+        );
+
+        let s = "Lorem\nipsum\ndolor\nANCHOR_END: test\nsit\namet";
+        assert_eq!(
+            take_rustdoc_include_anchored_lines(s, "test"),
+            "# Lorem\n# ipsum\n# dolor\n# sit\n# amet"
+        );
+
+        let s = "Lorem\nipsum\nANCHOR: test\ndolor\nsit\namet";
+        assert_eq!(
+            take_rustdoc_include_anchored_lines(s, "test"),
+            "# Lorem\n# ipsum\ndolor\nsit\namet"
+        );
+        assert_eq!(
+            take_rustdoc_include_anchored_lines(s, "something"),
+            "# Lorem\n# ipsum\n# dolor\n# sit\n# amet"
+        );
+
+        let s = "Lorem\nipsum\nANCHOR: test\ndolor\nsit\namet\nANCHOR_END: test\nlorem\nipsum";
+        assert_eq!(
+            take_rustdoc_include_anchored_lines(s, "test"),
+            "# Lorem\n# ipsum\ndolor\nsit\namet\n# lorem\n# ipsum"
+        );
+        assert_eq!(
+            take_rustdoc_include_anchored_lines(s, "something"),
+            "# Lorem\n# ipsum\n# dolor\n# sit\n# amet\n# lorem\n# ipsum"
+        );
+
+        let s = "Lorem\nANCHOR: test\nipsum\nANCHOR: test\ndolor\nsit\namet\nANCHOR_END: test\nlorem\nipsum";
+        assert_eq!(
+            take_rustdoc_include_anchored_lines(s, "test"),
+            "# Lorem\nipsum\ndolor\nsit\namet\n# lorem\n# ipsum"
+        );
+        assert_eq!(
+            take_rustdoc_include_anchored_lines(s, "something"),
+            "# Lorem\n# ipsum\n# dolor\n# sit\n# amet\n# lorem\n# ipsum"
+        );
+
+        let s = "Lorem\nANCHOR:    test2\nipsum\nANCHOR: test\ndolor\nsit\namet\nANCHOR_END: test\nlorem\nANCHOR_END:test2\nipsum";
+        assert_eq!(
+            take_rustdoc_include_anchored_lines(s, "test2"),
+            "# Lorem\nipsum\ndolor\nsit\namet\nlorem\n# ipsum"
+        );
+        assert_eq!(
+            take_rustdoc_include_anchored_lines(s, "test"),
+            "# Lorem\n# ipsum\ndolor\nsit\namet\n# lorem\n# ipsum"
+        );
+        assert_eq!(
+            take_rustdoc_include_anchored_lines(s, "something"),
+            "# Lorem\n# ipsum\n# dolor\n# sit\n# amet\n# lorem\n# ipsum"
+        );
     }
 }

--- a/tests/dummy_book/mod.rs
+++ b/tests/dummy_book/mod.rs
@@ -56,6 +56,8 @@ impl DummyBook {
             "src/first/nested.md",
             "src/first/nested-test.rs",
             "src/first/nested-test-with-anchors.rs",
+            "src/first/partially-included-test.rs",
+            "src/first/partially-included-test-with-anchors.rs",
         ];
         for file in &files_containing_tests {
             let path_containing_tests = temp.path().join(file);

--- a/tests/dummy_book/mod.rs
+++ b/tests/dummy_book/mod.rs
@@ -52,7 +52,11 @@ impl DummyBook {
         })?;
 
         let sub_pattern = if self.passing_test { "true" } else { "false" };
-        let files_containing_tests = ["src/first/nested.md", "src/first/nested-test.rs"];
+        let files_containing_tests = [
+            "src/first/nested.md",
+            "src/first/nested-test.rs",
+            "src/first/nested-test-with-anchors.rs",
+        ];
         for file in &files_containing_tests {
             let path_containing_tests = temp.path().join(file);
             replace_pattern_in_file(&path_containing_tests, "$TEST_STATUS", sub_pattern)?;

--- a/tests/dummy_book/src/first/nested-test-with-anchors.rs
+++ b/tests/dummy_book/src/first/nested-test-with-anchors.rs
@@ -1,0 +1,11 @@
+// The next line will cause a `testing` test to fail if the anchor feature is broken in such a way
+// that the whole file gets mistakenly included.
+assert!(!$TEST_STATUS);
+
+// ANCHOR: myanchor
+// ANCHOR: unendinganchor
+// The next line will cause a `rendered_output` test to fail if the anchor feature is broken in
+// such a way that the content between anchors isn't included.
+// unique-string-for-anchor-test
+assert!($TEST_STATUS);
+// ANCHOR_END: myanchor

--- a/tests/dummy_book/src/first/nested.md
+++ b/tests/dummy_book/src/first/nested.md
@@ -17,3 +17,15 @@ assert!($TEST_STATUS);
 ```rust
 {{#include nested-test-with-anchors.rs:myanchor}}
 ```
+
+## Rustdoc include adds the rest of the file as hidden
+
+```rust
+{{#rustdoc_include partially-included-test.rs:5:7}}
+```
+
+## Rustdoc include works with anchors too
+
+```rust
+{{#rustdoc_include partially-included-test-with-anchors.rs:rustdoc-include-anchor}}
+```

--- a/tests/dummy_book/src/first/nested.md
+++ b/tests/dummy_book/src/first/nested.md
@@ -11,3 +11,9 @@ assert!($TEST_STATUS);
 ```rust
 {{#include nested-test.rs}}
 ```
+
+## Anchors include the part of a file between special comments
+
+```rust
+{{#include nested-test-with-anchors.rs:myanchor}}
+```

--- a/tests/dummy_book/src/first/partially-included-test-with-anchors.rs
+++ b/tests/dummy_book/src/first/partially-included-test-with-anchors.rs
@@ -1,0 +1,11 @@
+fn some_other_function() {
+    // ANCHOR: unused-anchor-that-should-be-stripped
+    assert!($TEST_STATUS);
+    // ANCHOR_END: unused-anchor-that-should-be-stripped
+}
+
+// ANCHOR: rustdoc-include-anchor
+fn main() {
+    some_other_function();
+}
+// ANCHOR_END: rustdoc-include-anchor

--- a/tests/dummy_book/src/first/partially-included-test.rs
+++ b/tests/dummy_book/src/first/partially-included-test.rs
@@ -1,0 +1,7 @@
+fn some_function() {
+    assert!($TEST_STATUS);
+}
+
+fn main() {
+    some_function();
+}

--- a/tests/rendered_output.rs
+++ b/tests/rendered_output.rs
@@ -162,6 +162,18 @@ fn anchors_include_text_between_but_not_anchor_comments() {
 }
 
 #[test]
+fn rustdoc_include_hides_the_unspecified_part_of_the_file() {
+    let temp = DummyBook::new().build().unwrap();
+    let md = MDBook::load(temp.path()).unwrap();
+    md.build().unwrap();
+
+    let nested = temp.path().join("book/first/nested.html");
+    let text = vec!["# fn some_function() {", "# fn some_other_function() {"];
+
+    assert_contains_strings(nested, &text);
+}
+
+#[test]
 fn chapter_content_appears_in_rendered_document() {
     let content = vec![
         ("index.html", "This file is just here to cause the"),

--- a/tests/rendered_output.rs
+++ b/tests/rendered_output.rs
@@ -148,6 +148,20 @@ fn rendered_code_has_playpen_stuff() {
 }
 
 #[test]
+fn anchors_include_text_between_but_not_anchor_comments() {
+    let temp = DummyBook::new().build().unwrap();
+    let md = MDBook::load(temp.path()).unwrap();
+    md.build().unwrap();
+
+    let nested = temp.path().join("book/first/nested.html");
+    let text_between_anchors = vec!["unique-string-for-anchor-test"];
+    let anchor_text = vec!["ANCHOR"];
+
+    assert_contains_strings(nested.clone(), &text_between_anchors);
+    assert_doesnt_contain_strings(nested, &anchor_text);
+}
+
+#[test]
 fn chapter_content_appears_in_rendered_document() {
     let content = vec![
         ("index.html", "This file is just here to cause the"),

--- a/tests/searchindex_fixture.json
+++ b/tests/searchindex_fixture.json
@@ -6,6 +6,9 @@
     "first/index.html#some-section",
     "first/nested.html#nested-chapter",
     "first/nested.html#some-section",
+    "first/nested.html#anchors-include-the-part-of-a-file-between-special-comments",
+    "first/nested.html#rustdoc-include-adds-the-rest-of-the-file-as-hidden",
+    "first/nested.html#rustdoc-include-works-with-anchors-too",
     "first/includes.html#includes",
     "first/includes.html#summary",
     "first/markdown.html#markdown-tests",
@@ -33,49 +36,64 @@
           "title": 1
         },
         "10": {
-          "body": 12,
+          "body": 16,
           "breadcrumbs": 3,
           "title": 1
         },
         "11": {
-          "body": 2,
-          "breadcrumbs": 3,
-          "title": 1
+          "body": 3,
+          "breadcrumbs": 4,
+          "title": 2
         },
         "12": {
-          "body": 3,
+          "body": 4,
           "breadcrumbs": 3,
           "title": 1
         },
         "13": {
+          "body": 12,
+          "breadcrumbs": 3,
+          "title": 1
+        },
+        "14": {
+          "body": 2,
+          "breadcrumbs": 3,
+          "title": 1
+        },
+        "15": {
+          "body": 3,
+          "breadcrumbs": 3,
+          "title": 1
+        },
+        "16": {
           "body": 29,
           "breadcrumbs": 5,
           "title": 3
         },
-        "14": {
+        "17": {
           "body": 20,
           "breadcrumbs": 2,
           "title": 2
         },
-        "15": {
+        "18": {
           "body": 18,
           "breadcrumbs": 7,
           "title": 5
         },
-        "16": {
+        "19": {
           "body": 0,
           "breadcrumbs": 3,
-          "title": 1
-        },
-        "17": {
-          "body": 3,
-          "breadcrumbs": 1,
           "title": 1
         },
         "2": {
           "body": 2,
           "breadcrumbs": 2,
           "title": 2
+        },
+        "20": {
+          "body": 3,
+          "breadcrumbs": 1,
+          "title": 1
         },
         "3": {
           "body": 0,
@@ -93,22 +111,22 @@
           "title": 1
         },
         "6": {
-          "body": 0,
-          "breadcrumbs": 3,
-          "title": 1
+          "body": 21,
+          "breadcrumbs": 9,
+          "title": 7
         },
         "7": {
-          "body": 16,
-          "breadcrumbs": 3,
-          "title": 1
+          "body": 6,
+          "breadcrumbs": 8,
+          "title": 6
         },
         "8": {
-          "body": 3,
-          "breadcrumbs": 4,
-          "title": 2
+          "body": 6,
+          "breadcrumbs": 6,
+          "title": 4
         },
         "9": {
-          "body": 4,
+          "body": 0,
           "breadcrumbs": 3,
           "title": 1
         }
@@ -127,58 +145,76 @@
           "title": "Introduction"
         },
         "10": {
-          "body": "Footnote example [1] , or with a word [2] . This is a footnote. A longer footnote. With multiple lines. Third line.",
-          "breadcrumbs": "First Chapter » Footnotes",
+          "body": "Dummy Book Introduction First Chapter Nested Chapter Includes Recursive Markdown Unicode Second Chapter Nested Chapter Conclusion",
+          "breadcrumbs": "First Chapter » Summary",
           "id": "10",
-          "title": "Footnotes"
+          "title": "Summary"
         },
         "11": {
-          "body": "strikethrough example",
-          "breadcrumbs": "First Chapter » Strikethrough",
+          "body": "Tests for some markdown output.",
+          "breadcrumbs": "First Chapter » Markdown tests",
           "id": "11",
-          "title": "Strikethrough"
+          "title": "Markdown tests"
         },
         "12": {
-          "body": "Apples Broccoli Carrots",
-          "breadcrumbs": "First Chapter » Tasklisks",
+          "body": "foo bar baz bim",
+          "breadcrumbs": "First Chapter » Tables",
           "id": "12",
-          "title": "Tasklisks"
+          "title": "Tables"
         },
         "13": {
-          "body": "Please be careful editing, this contains carefully crafted characters. Two byte character: spatiëring Combining character: spatiëring Three byte character: 书こんにちは Four byte character: 𐌀‮𐌁‮𐌂‮𐌃‮𐌄‮𐌅‮𐌆‮𐌇‮𐌈‬ Right-to-left: مرحبا Emoticons: 🔊 😍 💜 1️⃣ right-to-left mark: hello באמת!‏ Zalgo: ǫ̛̖̱̗̝͈̋͒͋̏ͥͫ̒̆ͩ̏͌̾͊͐ͪ̾̚",
-          "breadcrumbs": "First Chapter » Unicode stress tests",
+          "body": "Footnote example [1] , or with a word [2] . This is a footnote. A longer footnote. With multiple lines. Third line.",
+          "breadcrumbs": "First Chapter » Footnotes",
           "id": "13",
-          "title": "Unicode stress tests"
+          "title": "Footnotes"
         },
         "14": {
-          "body": "This makes sure you can insert runnable Rust files. fn main() { println!(\"Hello World!\");\n#\n# // You can even hide lines! :D\n# println!(\"I am hidden! Expand the code snippet to see me\");\n}",
-          "breadcrumbs": "Second Chapter",
+          "body": "strikethrough example",
+          "breadcrumbs": "First Chapter » Strikethrough",
           "id": "14",
-          "title": "Second Chapter"
+          "title": "Strikethrough"
         },
         "15": {
-          "body": "When we link to the first section , it should work on both the print page and the non-print page. A fragment link should work. Link outside . Some image HTML Link",
-          "breadcrumbs": "Second Chapter » Testing relative links for the print page",
+          "body": "Apples Broccoli Carrots",
+          "breadcrumbs": "First Chapter » Tasklisks",
           "id": "15",
-          "title": "Testing relative links for the print page"
+          "title": "Tasklisks"
         },
         "16": {
-          "body": "",
-          "breadcrumbs": "Second Chapter » Some section",
+          "body": "Please be careful editing, this contains carefully crafted characters. Two byte character: spatiëring Combining character: spatiëring Three byte character: 书こんにちは Four byte character: 𐌀‮𐌁‮𐌂‮𐌃‮𐌄‮𐌅‮𐌆‮𐌇‮𐌈‬ Right-to-left: مرحبا Emoticons: 🔊 😍 💜 1️⃣ right-to-left mark: hello באמת!‏ Zalgo: ǫ̛̖̱̗̝͈̋͒͋̏ͥͫ̒̆ͩ̏͌̾͊͐ͪ̾̚",
+          "breadcrumbs": "First Chapter » Unicode stress tests",
           "id": "16",
-          "title": "Some section"
+          "title": "Unicode stress tests"
         },
         "17": {
-          "body": "I put &lt;HTML&gt; in here!",
-          "breadcrumbs": "Conclusion",
+          "body": "This makes sure you can insert runnable Rust files. fn main() { println!(\"Hello World!\");\n#\n# // You can even hide lines! :D\n# println!(\"I am hidden! Expand the code snippet to see me\");\n}",
+          "breadcrumbs": "Second Chapter",
           "id": "17",
-          "title": "Conclusion"
+          "title": "Second Chapter"
+        },
+        "18": {
+          "body": "When we link to the first section , it should work on both the print page and the non-print page. A fragment link should work. Link outside . Some image HTML Link",
+          "breadcrumbs": "Second Chapter » Testing relative links for the print page",
+          "id": "18",
+          "title": "Testing relative links for the print page"
+        },
+        "19": {
+          "body": "",
+          "breadcrumbs": "Second Chapter » Some section",
+          "id": "19",
+          "title": "Some section"
         },
         "2": {
           "body": "more text.",
           "breadcrumbs": "First Chapter",
           "id": "2",
           "title": "First Chapter"
+        },
+        "20": {
+          "body": "I put &lt;HTML&gt; in here!",
+          "breadcrumbs": "Conclusion",
+          "id": "20",
+          "title": "Conclusion"
         },
         "3": {
           "body": "",
@@ -199,31 +235,31 @@
           "title": "Some Section"
         },
         "6": {
-          "body": "",
-          "breadcrumbs": "First Chapter » Includes",
+          "body": "// The next line will cause a `rendered_output` test to fail if the anchor feature is broken in\n// such a way that the content between anchors isn't included.\n// unique-string-for-anchor-test\nassert!(true);",
+          "breadcrumbs": "First Chapter » Anchors include the part of a file between special comments",
           "id": "6",
-          "title": "Includes"
+          "title": "Anchors include the part of a file between special comments"
         },
         "7": {
-          "body": "Dummy Book Introduction First Chapter Nested Chapter Includes Recursive Markdown Unicode Second Chapter Nested Chapter Conclusion",
-          "breadcrumbs": "First Chapter » Summary",
+          "body": "# fn some_function() {\n# assert!(true);\n# }\n# fn main() { some_function();\n}",
+          "breadcrumbs": "First Chapter » Rustdoc include adds the rest of the file as hidden",
           "id": "7",
-          "title": "Summary"
+          "title": "Rustdoc include adds the rest of the file as hidden"
         },
         "8": {
-          "body": "Tests for some markdown output.",
-          "breadcrumbs": "First Chapter » Markdown tests",
+          "body": "# fn some_other_function() {\n# assert!(true);\n# }\n# fn main() { some_other_function();\n}",
+          "breadcrumbs": "First Chapter » Rustdoc include works with anchors too",
           "id": "8",
-          "title": "Markdown tests"
+          "title": "Rustdoc include works with anchors too"
         },
         "9": {
-          "body": "foo bar baz bim",
-          "breadcrumbs": "First Chapter » Tables",
+          "body": "",
+          "breadcrumbs": "First Chapter » Includes",
           "id": "9",
-          "title": "Tables"
+          "title": "Includes"
         }
       },
-      "length": 18,
+      "length": 21,
       "save": true
     },
     "fields": [
@@ -237,10 +273,10 @@
           "1": {
             "df": 2,
             "docs": {
-              "10": {
+              "13": {
                 "tf": 1.0
               },
-              "13": {
+              "16": {
                 "tf": 1.0
               }
             }
@@ -248,14 +284,53 @@
           "2": {
             "df": 1,
             "docs": {
-              "10": {
+              "13": {
                 "tf": 1.0
               }
             }
           },
           "a": {
+            "d": {
+              "d": {
+                "df": 1,
+                "docs": {
+                  "7": {
+                    "tf": 1.0
+                  }
+                }
+              },
+              "df": 0,
+              "docs": {}
+            },
             "df": 0,
             "docs": {},
+            "n": {
+              "c": {
+                "df": 0,
+                "docs": {},
+                "h": {
+                  "df": 0,
+                  "docs": {},
+                  "o": {
+                    "df": 0,
+                    "docs": {},
+                    "r": {
+                      "df": 2,
+                      "docs": {
+                        "6": {
+                          "tf": 2.0
+                        },
+                        "8": {
+                          "tf": 1.0
+                        }
+                      }
+                    }
+                  }
+                }
+              },
+              "df": 0,
+              "docs": {}
+            },
             "p": {
               "df": 0,
               "docs": {},
@@ -265,7 +340,7 @@
                 "l": {
                   "df": 1,
                   "docs": {
-                    "12": {
+                    "15": {
                       "tf": 1.0
                     }
                   }
@@ -296,12 +371,21 @@
                               "df": 0,
                               "docs": {},
                               "u": {
-                                "df": 2,
+                                "df": 5,
                                 "docs": {
                                   "4": {
                                     "tf": 1.0
                                   },
                                   "5": {
+                                    "tf": 1.0
+                                  },
+                                  "6": {
+                                    "tf": 1.0
+                                  },
+                                  "7": {
+                                    "tf": 1.0
+                                  },
+                                  "8": {
                                     "tf": 1.0
                                   }
                                 }
@@ -327,7 +411,7 @@
               "r": {
                 "df": 1,
                 "docs": {
-                  "9": {
+                  "12": {
                     "tf": 1.0
                   }
                 }
@@ -335,7 +419,7 @@
               "z": {
                 "df": 1,
                 "docs": {
-                  "9": {
+                  "12": {
                     "tf": 1.0
                   }
                 }
@@ -343,13 +427,41 @@
             },
             "df": 0,
             "docs": {},
+            "e": {
+              "df": 0,
+              "docs": {},
+              "t": {
+                "df": 0,
+                "docs": {},
+                "w": {
+                  "df": 0,
+                  "docs": {},
+                  "e": {
+                    "df": 0,
+                    "docs": {},
+                    "e": {
+                      "df": 0,
+                      "docs": {},
+                      "n": {
+                        "df": 1,
+                        "docs": {
+                          "6": {
+                            "tf": 1.4142135623730951
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
             "i": {
               "df": 0,
               "docs": {},
               "m": {
                 "df": 1,
                 "docs": {
-                  "9": {
+                  "12": {
                     "tf": 1.0
                   }
                 }
@@ -367,7 +479,7 @@
                     "0": {
                       "tf": 1.0
                     },
-                    "7": {
+                    "10": {
                       "tf": 1.0
                     }
                   }
@@ -379,7 +491,7 @@
                 "h": {
                   "df": 1,
                   "docs": {
-                    "15": {
+                    "18": {
                       "tf": 1.0
                     }
                   }
@@ -403,7 +515,7 @@
                         "i": {
                           "df": 1,
                           "docs": {
-                            "12": {
+                            "15": {
                               "tf": 1.0
                             }
                           }
@@ -415,7 +527,23 @@
                   "docs": {}
                 },
                 "df": 0,
-                "docs": {}
+                "docs": {},
+                "k": {
+                  "df": 0,
+                  "docs": {},
+                  "e": {
+                    "df": 0,
+                    "docs": {},
+                    "n": {
+                      "df": 1,
+                      "docs": {
+                        "6": {
+                          "tf": 1.0
+                        }
+                      }
+                    }
+                  }
+                }
               }
             },
             "y": {
@@ -427,7 +555,7 @@
                 "e": {
                   "df": 1,
                   "docs": {
-                    "13": {
+                    "16": {
                       "tf": 1.7320508075688772
                     }
                   }
@@ -445,7 +573,7 @@
                 "e": {
                   "df": 1,
                   "docs": {
-                    "13": {
+                    "16": {
                       "tf": 1.0
                     }
                   },
@@ -464,7 +592,7 @@
                           "i": {
                             "df": 1,
                             "docs": {
-                              "13": {
+                              "16": {
                                 "tf": 1.0
                               }
                             }
@@ -483,7 +611,7 @@
                     "t": {
                       "df": 1,
                       "docs": {
-                        "12": {
+                        "15": {
                           "tf": 1.0
                         }
                       }
@@ -495,9 +623,12 @@
                 "df": 0,
                 "docs": {},
                 "s": {
-                  "df": 1,
+                  "df": 2,
                   "docs": {
                     "0": {
+                      "tf": 1.0
+                    },
+                    "6": {
                       "tf": 1.0
                     }
                   }
@@ -522,7 +653,10 @@
                       "r": {
                         "df": 4,
                         "docs": {
-                          "14": {
+                          "10": {
+                            "tf": 2.0
+                          },
+                          "17": {
                             "tf": 1.0
                           },
                           "2": {
@@ -530,9 +664,6 @@
                           },
                           "4": {
                             "tf": 1.0
-                          },
-                          "7": {
-                            "tf": 2.0
                           }
                         }
                       }
@@ -547,7 +678,7 @@
                       "t": {
                         "df": 1,
                         "docs": {
-                          "13": {
+                          "16": {
                             "tf": 2.23606797749979
                           }
                         }
@@ -570,7 +701,7 @@
                 "e": {
                   "df": 2,
                   "docs": {
-                    "14": {
+                    "17": {
                       "tf": 1.0
                     },
                     "4": {
@@ -591,7 +722,7 @@
                     "n": {
                       "df": 1,
                       "docs": {
-                        "13": {
+                        "16": {
                           "tf": 1.0
                         }
                       }
@@ -599,7 +730,27 @@
                   }
                 },
                 "df": 0,
-                "docs": {}
+                "docs": {},
+                "m": {
+                  "df": 0,
+                  "docs": {},
+                  "e": {
+                    "df": 0,
+                    "docs": {},
+                    "n": {
+                      "df": 0,
+                      "docs": {},
+                      "t": {
+                        "df": 1,
+                        "docs": {
+                          "6": {
+                            "tf": 1.0
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
               },
               "n": {
                 "c": {
@@ -614,10 +765,10 @@
                       "s": {
                         "df": 2,
                         "docs": {
-                          "17": {
+                          "10": {
                             "tf": 1.0
                           },
-                          "7": {
+                          "20": {
                             "tf": 1.0
                           }
                         }
@@ -637,7 +788,7 @@
                       "n": {
                         "df": 1,
                         "docs": {
-                          "13": {
+                          "16": {
                             "tf": 1.0
                           }
                         }
@@ -645,7 +796,23 @@
                     }
                   },
                   "df": 0,
-                  "docs": {}
+                  "docs": {},
+                  "e": {
+                    "df": 0,
+                    "docs": {},
+                    "n": {
+                      "df": 0,
+                      "docs": {},
+                      "t": {
+                        "df": 1,
+                        "docs": {
+                          "6": {
+                            "tf": 1.0
+                          }
+                        }
+                      }
+                    }
+                  }
                 }
               }
             },
@@ -659,7 +826,7 @@
                   "t": {
                     "df": 1,
                     "docs": {
-                      "13": {
+                      "16": {
                         "tf": 1.0
                       }
                     }
@@ -673,7 +840,7 @@
           "d": {
             "df": 1,
             "docs": {
-              "14": {
+              "17": {
                 "tf": 1.0
               }
             },
@@ -692,7 +859,7 @@
                       "0": {
                         "tf": 1.0
                       },
-                      "7": {
+                      "10": {
                         "tf": 1.0
                       }
                     }
@@ -713,7 +880,7 @@
                 "t": {
                   "df": 1,
                   "docs": {
-                    "13": {
+                    "16": {
                       "tf": 1.0
                     }
                   }
@@ -741,7 +908,7 @@
                         "n": {
                           "df": 1,
                           "docs": {
-                            "13": {
+                            "16": {
                               "tf": 1.0
                             }
                           }
@@ -763,7 +930,7 @@
                 "n": {
                   "df": 1,
                   "docs": {
-                    "14": {
+                    "17": {
                       "tf": 1.0
                     }
                   }
@@ -783,10 +950,10 @@
                     "l": {
                       "df": 2,
                       "docs": {
-                        "10": {
+                        "13": {
                           "tf": 1.0
                         },
-                        "11": {
+                        "14": {
                           "tf": 1.0
                         }
                       }
@@ -804,7 +971,7 @@
                     "d": {
                       "df": 1,
                       "docs": {
-                        "14": {
+                        "17": {
                           "tf": 1.0
                         }
                       }
@@ -819,8 +986,48 @@
             }
           },
           "f": {
+            "a": {
+              "df": 0,
+              "docs": {},
+              "i": {
+                "df": 0,
+                "docs": {},
+                "l": {
+                  "df": 1,
+                  "docs": {
+                    "6": {
+                      "tf": 1.0
+                    }
+                  }
+                }
+              }
+            },
             "df": 0,
             "docs": {},
+            "e": {
+              "a": {
+                "df": 0,
+                "docs": {},
+                "t": {
+                  "df": 0,
+                  "docs": {},
+                  "u": {
+                    "df": 0,
+                    "docs": {},
+                    "r": {
+                      "df": 1,
+                      "docs": {
+                        "6": {
+                          "tf": 1.0
+                        }
+                      }
+                    }
+                  }
+                }
+              },
+              "df": 0,
+              "docs": {}
+            },
             "i": {
               "df": 0,
               "docs": {},
@@ -828,15 +1035,21 @@
                 "df": 0,
                 "docs": {},
                 "e": {
-                  "df": 3,
+                  "df": 5,
                   "docs": {
                     "0": {
                       "tf": 1.0
                     },
-                    "14": {
+                    "17": {
                       "tf": 1.0
                     },
                     "4": {
+                      "tf": 1.0
+                    },
+                    "6": {
+                      "tf": 1.0
+                    },
+                    "7": {
                       "tf": 1.0
                     }
                   }
@@ -851,13 +1064,13 @@
                   "t": {
                     "df": 3,
                     "docs": {
-                      "15": {
+                      "10": {
+                        "tf": 1.0
+                      },
+                      "18": {
                         "tf": 1.0
                       },
                       "2": {
-                        "tf": 1.0
-                      },
-                      "7": {
                         "tf": 1.0
                       }
                     }
@@ -866,10 +1079,16 @@
               }
             },
             "n": {
-              "df": 1,
+              "df": 3,
               "docs": {
-                "14": {
+                "17": {
                   "tf": 1.0
+                },
+                "7": {
+                  "tf": 1.4142135623730951
+                },
+                "8": {
+                  "tf": 1.4142135623730951
                 }
               }
             },
@@ -879,7 +1098,7 @@
               "o": {
                 "df": 1,
                 "docs": {
-                  "9": {
+                  "12": {
                     "tf": 1.0
                   }
                 },
@@ -895,7 +1114,7 @@
                       "t": {
                         "df": 1,
                         "docs": {
-                          "10": {
+                          "13": {
                             "tf": 2.0
                           }
                         }
@@ -910,7 +1129,7 @@
                 "r": {
                   "df": 1,
                   "docs": {
-                    "13": {
+                    "16": {
                       "tf": 1.0
                     }
                   }
@@ -936,7 +1155,7 @@
                         "t": {
                           "df": 1,
                           "docs": {
-                            "15": {
+                            "18": {
                               "tf": 1.0
                             }
                           }
@@ -985,7 +1204,7 @@
                   "o": {
                     "df": 1,
                     "docs": {
-                      "13": {
+                      "16": {
                         "tf": 1.0
                       }
                     }
@@ -1009,7 +1228,7 @@
                     "0": {
                       "tf": 1.0
                     },
-                    "17": {
+                    "20": {
                       "tf": 1.0
                     }
                   }
@@ -1025,9 +1244,12 @@
                     "df": 0,
                     "docs": {},
                     "n": {
-                      "df": 1,
+                      "df": 2,
                       "docs": {
-                        "14": {
+                        "17": {
+                          "tf": 1.0
+                        },
+                        "7": {
                           "tf": 1.0
                         }
                       }
@@ -1039,7 +1261,7 @@
                 "e": {
                   "df": 1,
                   "docs": {
-                    "14": {
+                    "17": {
                       "tf": 1.0
                     }
                   }
@@ -1057,7 +1279,7 @@
                 "l": {
                   "df": 1,
                   "docs": {
-                    "15": {
+                    "18": {
                       "tf": 1.0
                     }
                   }
@@ -1075,7 +1297,7 @@
                 "g": {
                   "df": 1,
                   "docs": {
-                    "15": {
+                    "18": {
                       "tf": 1.0
                     }
                   }
@@ -1093,12 +1315,21 @@
                   "docs": {},
                   "u": {
                     "d": {
-                      "df": 2,
+                      "df": 5,
                       "docs": {
-                        "6": {
+                        "10": {
                           "tf": 1.0
                         },
+                        "6": {
+                          "tf": 1.4142135623730951
+                        },
                         "7": {
+                          "tf": 1.0
+                        },
+                        "8": {
+                          "tf": 1.0
+                        },
+                        "9": {
                           "tf": 1.0
                         }
                       }
@@ -1138,7 +1369,7 @@
                     "t": {
                       "df": 1,
                       "docs": {
-                        "14": {
+                        "17": {
                           "tf": 1.0
                         }
                       }
@@ -1190,7 +1421,7 @@
                               "1": {
                                 "tf": 1.0
                               },
-                              "7": {
+                              "10": {
                                 "tf": 1.0
                               }
                             }
@@ -1204,6 +1435,26 @@
                     "docs": {}
                   }
                 }
+              }
+            },
+            "s": {
+              "df": 0,
+              "docs": {},
+              "n": {
+                "'": {
+                  "df": 0,
+                  "docs": {},
+                  "t": {
+                    "df": 1,
+                    "docs": {
+                      "6": {
+                        "tf": 1.0
+                      }
+                    }
+                  }
+                },
+                "df": 0,
+                "docs": {}
               }
             }
           },
@@ -1235,7 +1486,7 @@
                 "t": {
                   "df": 1,
                   "docs": {
-                    "13": {
+                    "16": {
                       "tf": 1.4142135623730951
                     }
                   }
@@ -1249,12 +1500,15 @@
                 "df": 0,
                 "docs": {},
                 "e": {
-                  "df": 2,
+                  "df": 3,
                   "docs": {
-                    "10": {
+                    "13": {
                       "tf": 1.4142135623730951
                     },
-                    "14": {
+                    "17": {
+                      "tf": 1.0
+                    },
+                    "6": {
                       "tf": 1.0
                     }
                   }
@@ -1262,7 +1516,7 @@
                 "k": {
                   "df": 1,
                   "docs": {
-                    "15": {
+                    "18": {
                       "tf": 2.23606797749979
                     }
                   }
@@ -1284,7 +1538,7 @@
                     "r": {
                       "df": 1,
                       "docs": {
-                        "10": {
+                        "13": {
                           "tf": 1.0
                         }
                       }
@@ -1316,7 +1570,7 @@
                             "t": {
                               "df": 1,
                               "docs": {
-                                "17": {
+                                "20": {
                                   "tf": 1.0
                                 }
                               }
@@ -1342,9 +1596,15 @@
                 "df": 0,
                 "docs": {},
                 "n": {
-                  "df": 1,
+                  "df": 3,
                   "docs": {
-                    "14": {
+                    "17": {
+                      "tf": 1.0
+                    },
+                    "7": {
+                      "tf": 1.0
+                    },
+                    "8": {
                       "tf": 1.0
                     }
                   }
@@ -1356,7 +1616,7 @@
                 "e": {
                   "df": 1,
                   "docs": {
-                    "14": {
+                    "17": {
                       "tf": 1.0
                     }
                   }
@@ -1378,10 +1638,10 @@
                         "n": {
                           "df": 2,
                           "docs": {
-                            "7": {
+                            "10": {
                               "tf": 1.0
                             },
-                            "8": {
+                            "11": {
                               "tf": 1.4142135623730951
                             }
                           }
@@ -1391,7 +1651,7 @@
                   },
                   "df": 1,
                   "docs": {
-                    "13": {
+                    "16": {
                       "tf": 1.0
                     }
                   }
@@ -1434,7 +1694,7 @@
                       "l": {
                         "df": 1,
                         "docs": {
-                          "10": {
+                          "13": {
                             "tf": 1.0
                           }
                         }
@@ -1457,11 +1717,23 @@
                 "t": {
                   "df": 2,
                   "docs": {
+                    "10": {
+                      "tf": 1.4142135623730951
+                    },
                     "4": {
                       "tf": 1.0
-                    },
-                    "7": {
-                      "tf": 1.4142135623730951
+                    }
+                  }
+                }
+              },
+              "x": {
+                "df": 0,
+                "docs": {},
+                "t": {
+                  "df": 1,
+                  "docs": {
+                    "6": {
+                      "tf": 1.0
                     }
                   }
                 }
@@ -1473,7 +1745,7 @@
               "n": {
                 "df": 1,
                 "docs": {
-                  "15": {
+                  "18": {
                     "tf": 1.0
                   }
                 }
@@ -1498,7 +1770,7 @@
                     "t": {
                       "df": 1,
                       "docs": {
-                        "8": {
+                        "11": {
                           "tf": 1.0
                         }
                       }
@@ -1512,7 +1784,7 @@
                     "d": {
                       "df": 1,
                       "docs": {
-                        "15": {
+                        "18": {
                           "tf": 1.0
                         }
                       }
@@ -1534,8 +1806,20 @@
                 "e": {
                   "df": 1,
                   "docs": {
-                    "15": {
+                    "18": {
                       "tf": 1.7320508075688772
+                    }
+                  }
+                }
+              },
+              "r": {
+                "df": 0,
+                "docs": {},
+                "t": {
+                  "df": 1,
+                  "docs": {
+                    "6": {
+                      "tf": 1.0
                     }
                   }
                 }
@@ -1553,7 +1837,7 @@
                   "s": {
                     "df": 1,
                     "docs": {
-                      "13": {
+                      "16": {
                         "tf": 1.0
                       }
                     }
@@ -1635,7 +1919,7 @@
                   "t": {
                     "df": 1,
                     "docs": {
-                      "15": {
+                      "18": {
                         "tf": 1.7320508075688772
                       }
                     },
@@ -1663,7 +1947,7 @@
                                       "o": {
                                         "df": 1,
                                         "docs": {
-                                          "14": {
+                                          "17": {
                                             "tf": 1.0
                                           }
                                         }
@@ -1675,7 +1959,7 @@
                               "i": {
                                 "df": 1,
                                 "docs": {
-                                  "14": {
+                                  "17": {
                                     "tf": 1.0
                                   }
                                 }
@@ -1701,7 +1985,7 @@
               "t": {
                 "df": 1,
                 "docs": {
-                  "17": {
+                  "20": {
                     "tf": 1.0
                   }
                 }
@@ -1724,7 +2008,7 @@
                     "s": {
                       "df": 1,
                       "docs": {
-                        "7": {
+                        "10": {
                           "tf": 1.0
                         }
                       }
@@ -1737,8 +2021,76 @@
               "l": {
                 "df": 1,
                 "docs": {
-                  "15": {
+                  "18": {
                     "tf": 1.0
+                  }
+                }
+              },
+              "n": {
+                "d": {
+                  "df": 0,
+                  "docs": {},
+                  "e": {
+                    "df": 0,
+                    "docs": {},
+                    "r": {
+                      "df": 0,
+                      "docs": {},
+                      "e": {
+                        "d": {
+                          "_": {
+                            "df": 0,
+                            "docs": {},
+                            "o": {
+                              "df": 0,
+                              "docs": {},
+                              "u": {
+                                "df": 0,
+                                "docs": {},
+                                "t": {
+                                  "df": 0,
+                                  "docs": {},
+                                  "p": {
+                                    "df": 0,
+                                    "docs": {},
+                                    "u": {
+                                      "df": 0,
+                                      "docs": {},
+                                      "t": {
+                                        "df": 1,
+                                        "docs": {
+                                          "6": {
+                                            "tf": 1.0
+                                          }
+                                        }
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          },
+                          "df": 0,
+                          "docs": {}
+                        },
+                        "df": 0,
+                        "docs": {}
+                      }
+                    }
+                  }
+                },
+                "df": 0,
+                "docs": {}
+              },
+              "s": {
+                "df": 0,
+                "docs": {},
+                "t": {
+                  "df": 1,
+                  "docs": {
+                    "7": {
+                      "tf": 1.0
+                    }
                   }
                 }
               }
@@ -1755,7 +2107,7 @@
                   "t": {
                     "df": 1,
                     "docs": {
-                      "13": {
+                      "16": {
                         "tf": 1.4142135623730951
                       }
                     }
@@ -1781,7 +2133,7 @@
                       "l": {
                         "df": 1,
                         "docs": {
-                          "14": {
+                          "17": {
                             "tf": 1.0
                           }
                         }
@@ -1798,9 +2150,28 @@
                 "df": 0,
                 "docs": {},
                 "t": {
+                  "d": {
+                    "df": 0,
+                    "docs": {},
+                    "o": {
+                      "c": {
+                        "df": 2,
+                        "docs": {
+                          "7": {
+                            "tf": 1.0
+                          },
+                          "8": {
+                            "tf": 1.0
+                          }
+                        }
+                      },
+                      "df": 0,
+                      "docs": {}
+                    }
+                  },
                   "df": 1,
                   "docs": {
-                    "14": {
+                    "17": {
                       "tf": 1.0
                     }
                   }
@@ -1822,10 +2193,10 @@
                     "d": {
                       "df": 2,
                       "docs": {
-                        "14": {
+                        "10": {
                           "tf": 1.0
                         },
-                        "7": {
+                        "17": {
                           "tf": 1.0
                         }
                       }
@@ -1846,10 +2217,10 @@
                       "n": {
                         "df": 4,
                         "docs": {
-                          "15": {
+                          "18": {
                             "tf": 1.0
                           },
-                          "16": {
+                          "19": {
                             "tf": 1.0
                           },
                           "3": {
@@ -1869,7 +2240,7 @@
               "e": {
                 "df": 1,
                 "docs": {
-                  "14": {
+                  "17": {
                     "tf": 1.0
                   }
                 }
@@ -1893,13 +2264,101 @@
                       "t": {
                         "df": 1,
                         "docs": {
-                          "14": {
+                          "17": {
                             "tf": 1.0
                           }
                         }
                       }
                     }
                   }
+                }
+              }
+            },
+            "o": {
+              "df": 0,
+              "docs": {},
+              "m": {
+                "df": 0,
+                "docs": {},
+                "e": {
+                  "_": {
+                    "df": 0,
+                    "docs": {},
+                    "f": {
+                      "df": 0,
+                      "docs": {},
+                      "u": {
+                        "df": 0,
+                        "docs": {},
+                        "n": {
+                          "c": {
+                            "df": 0,
+                            "docs": {},
+                            "t": {
+                              "df": 1,
+                              "docs": {
+                                "7": {
+                                  "tf": 1.4142135623730951
+                                }
+                              }
+                            }
+                          },
+                          "df": 0,
+                          "docs": {}
+                        }
+                      }
+                    },
+                    "o": {
+                      "df": 0,
+                      "docs": {},
+                      "t": {
+                        "df": 0,
+                        "docs": {},
+                        "h": {
+                          "df": 0,
+                          "docs": {},
+                          "e": {
+                            "df": 0,
+                            "docs": {},
+                            "r": {
+                              "_": {
+                                "df": 0,
+                                "docs": {},
+                                "f": {
+                                  "df": 0,
+                                  "docs": {},
+                                  "u": {
+                                    "df": 0,
+                                    "docs": {},
+                                    "n": {
+                                      "c": {
+                                        "df": 0,
+                                        "docs": {},
+                                        "t": {
+                                          "df": 1,
+                                          "docs": {
+                                            "8": {
+                                              "tf": 1.4142135623730951
+                                            }
+                                          }
+                                        }
+                                      },
+                                      "df": 0,
+                                      "docs": {}
+                                    }
+                                  }
+                                }
+                              },
+                              "df": 0,
+                              "docs": {}
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "df": 0,
+                  "docs": {}
                 }
               }
             },
@@ -1922,7 +2381,7 @@
                         "r": {
                           "df": 1,
                           "docs": {
-                            "13": {
+                            "16": {
                               "tf": 1.0
                             }
                           }
@@ -1935,7 +2394,7 @@
                       "r": {
                         "df": 1,
                         "docs": {
-                          "13": {
+                          "16": {
                             "tf": 1.0
                           }
                         }
@@ -1945,7 +2404,31 @@
                 }
               },
               "df": 0,
-              "docs": {}
+              "docs": {},
+              "e": {
+                "c": {
+                  "df": 0,
+                  "docs": {},
+                  "i": {
+                    "a": {
+                      "df": 0,
+                      "docs": {},
+                      "l": {
+                        "df": 1,
+                        "docs": {
+                          "6": {
+                            "tf": 1.0
+                          }
+                        }
+                      }
+                    },
+                    "df": 0,
+                    "docs": {}
+                  }
+                },
+                "df": 0,
+                "docs": {}
+              }
             },
             "t": {
               "df": 0,
@@ -1962,7 +2445,7 @@
                     "s": {
                       "df": 1,
                       "docs": {
-                        "13": {
+                        "16": {
                           "tf": 1.0
                         }
                       }
@@ -1999,7 +2482,7 @@
                                   "h": {
                                     "df": 1,
                                     "docs": {
-                                      "11": {
+                                      "14": {
                                         "tf": 1.4142135623730951
                                       }
                                     }
@@ -2011,11 +2494,35 @@
                         }
                       }
                     }
+                  },
+                  "n": {
+                    "df": 0,
+                    "docs": {},
+                    "g": {
+                      "df": 1,
+                      "docs": {
+                        "6": {
+                          "tf": 1.0
+                        }
+                      }
+                    }
                   }
                 }
               }
             },
             "u": {
+              "c": {
+                "df": 0,
+                "docs": {},
+                "h": {
+                  "df": 1,
+                  "docs": {
+                    "6": {
+                      "tf": 1.0
+                    }
+                  }
+                }
+              },
               "df": 0,
               "docs": {},
               "m": {
@@ -2031,7 +2538,7 @@
                       "i": {
                         "df": 1,
                         "docs": {
-                          "7": {
+                          "10": {
                             "tf": 1.0
                           }
                         }
@@ -2048,7 +2555,7 @@
                 "e": {
                   "df": 1,
                   "docs": {
-                    "14": {
+                    "17": {
                       "tf": 1.0
                     }
                   }
@@ -2064,7 +2571,7 @@
                 "l": {
                   "df": 1,
                   "docs": {
-                    "9": {
+                    "12": {
                       "tf": 1.0
                     }
                   }
@@ -2090,7 +2597,7 @@
                         "k": {
                           "df": 1,
                           "docs": {
-                            "12": {
+                            "15": {
                               "tf": 1.0
                             }
                           }
@@ -2126,15 +2633,18 @@
                     "df": 0,
                     "docs": {}
                   },
-                  "df": 3,
+                  "df": 4,
                   "docs": {
-                    "13": {
+                    "11": {
+                      "tf": 1.4142135623730951
+                    },
+                    "16": {
                       "tf": 1.0
                     },
-                    "15": {
+                    "18": {
                       "tf": 1.0
                     },
-                    "8": {
+                    "6": {
                       "tf": 1.4142135623730951
                     }
                   }
@@ -2166,7 +2676,7 @@
                   "d": {
                     "df": 1,
                     "docs": {
-                      "10": {
+                      "13": {
                         "tf": 1.0
                       }
                     }
@@ -2184,7 +2694,7 @@
                   "e": {
                     "df": 1,
                     "docs": {
-                      "13": {
+                      "16": {
                         "tf": 1.0
                       }
                     }
@@ -2198,7 +2708,7 @@
               "o": {
                 "df": 1,
                 "docs": {
-                  "13": {
+                  "16": {
                     "tf": 1.0
                   }
                 }
@@ -2219,10 +2729,10 @@
                     "d": {
                       "df": 2,
                       "docs": {
-                        "13": {
+                        "10": {
                           "tf": 1.0
                         },
-                        "7": {
+                        "16": {
                           "tf": 1.0
                         }
                       }
@@ -2232,11 +2742,35 @@
                   }
                 },
                 "df": 0,
-                "docs": {}
+                "docs": {},
+                "q": {
+                  "df": 0,
+                  "docs": {},
+                  "u": {
+                    "df": 1,
+                    "docs": {
+                      "6": {
+                        "tf": 1.0
+                      }
+                    }
+                  }
+                }
               }
             }
           },
           "w": {
+            "a": {
+              "df": 0,
+              "docs": {},
+              "y": {
+                "df": 1,
+                "docs": {
+                  "6": {
+                    "tf": 1.0
+                  }
+                }
+              }
+            },
             "df": 0,
             "docs": {},
             "o": {
@@ -2246,7 +2780,7 @@
                 "d": {
                   "df": 1,
                   "docs": {
-                    "10": {
+                    "13": {
                       "tf": 1.0
                     }
                   }
@@ -2254,10 +2788,13 @@
                 "df": 0,
                 "docs": {},
                 "k": {
-                  "df": 1,
+                  "df": 2,
                   "docs": {
-                    "15": {
+                    "18": {
                       "tf": 1.4142135623730951
+                    },
+                    "8": {
+                      "tf": 1.0
                     }
                   }
                 },
@@ -2265,7 +2802,7 @@
                   "d": {
                     "df": 1,
                     "docs": {
-                      "14": {
+                      "17": {
                         "tf": 1.0
                       }
                     }
@@ -2289,7 +2826,7 @@
                   "o": {
                     "df": 1,
                     "docs": {
-                      "13": {
+                      "16": {
                         "tf": 1.0
                       }
                     }
@@ -2307,10 +2844,10 @@
           "1": {
             "df": 2,
             "docs": {
-              "10": {
+              "13": {
                 "tf": 1.0
               },
-              "13": {
+              "16": {
                 "tf": 1.0
               }
             }
@@ -2318,14 +2855,53 @@
           "2": {
             "df": 1,
             "docs": {
-              "10": {
+              "13": {
                 "tf": 1.0
               }
             }
           },
           "a": {
+            "d": {
+              "d": {
+                "df": 1,
+                "docs": {
+                  "7": {
+                    "tf": 1.4142135623730951
+                  }
+                }
+              },
+              "df": 0,
+              "docs": {}
+            },
             "df": 0,
             "docs": {},
+            "n": {
+              "c": {
+                "df": 0,
+                "docs": {},
+                "h": {
+                  "df": 0,
+                  "docs": {},
+                  "o": {
+                    "df": 0,
+                    "docs": {},
+                    "r": {
+                      "df": 2,
+                      "docs": {
+                        "6": {
+                          "tf": 2.23606797749979
+                        },
+                        "8": {
+                          "tf": 1.4142135623730951
+                        }
+                      }
+                    }
+                  }
+                }
+              },
+              "df": 0,
+              "docs": {}
+            },
             "p": {
               "df": 0,
               "docs": {},
@@ -2335,7 +2911,7 @@
                 "l": {
                   "df": 1,
                   "docs": {
-                    "12": {
+                    "15": {
                       "tf": 1.0
                     }
                   }
@@ -2366,12 +2942,21 @@
                               "df": 0,
                               "docs": {},
                               "u": {
-                                "df": 2,
+                                "df": 5,
                                 "docs": {
                                   "4": {
                                     "tf": 1.0
                                   },
                                   "5": {
+                                    "tf": 1.0
+                                  },
+                                  "6": {
+                                    "tf": 1.0
+                                  },
+                                  "7": {
+                                    "tf": 1.0
+                                  },
+                                  "8": {
                                     "tf": 1.0
                                   }
                                 }
@@ -2397,7 +2982,7 @@
               "r": {
                 "df": 1,
                 "docs": {
-                  "9": {
+                  "12": {
                     "tf": 1.0
                   }
                 }
@@ -2405,7 +2990,7 @@
               "z": {
                 "df": 1,
                 "docs": {
-                  "9": {
+                  "12": {
                     "tf": 1.0
                   }
                 }
@@ -2413,13 +2998,41 @@
             },
             "df": 0,
             "docs": {},
+            "e": {
+              "df": 0,
+              "docs": {},
+              "t": {
+                "df": 0,
+                "docs": {},
+                "w": {
+                  "df": 0,
+                  "docs": {},
+                  "e": {
+                    "df": 0,
+                    "docs": {},
+                    "e": {
+                      "df": 0,
+                      "docs": {},
+                      "n": {
+                        "df": 1,
+                        "docs": {
+                          "6": {
+                            "tf": 1.7320508075688772
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
             "i": {
               "df": 0,
               "docs": {},
               "m": {
                 "df": 1,
                 "docs": {
-                  "9": {
+                  "12": {
                     "tf": 1.0
                   }
                 }
@@ -2437,7 +3050,7 @@
                     "0": {
                       "tf": 1.4142135623730951
                     },
-                    "7": {
+                    "10": {
                       "tf": 1.0
                     }
                   }
@@ -2449,7 +3062,7 @@
                 "h": {
                   "df": 1,
                   "docs": {
-                    "15": {
+                    "18": {
                       "tf": 1.0
                     }
                   }
@@ -2473,7 +3086,7 @@
                         "i": {
                           "df": 1,
                           "docs": {
-                            "12": {
+                            "15": {
                               "tf": 1.0
                             }
                           }
@@ -2485,7 +3098,23 @@
                   "docs": {}
                 },
                 "df": 0,
-                "docs": {}
+                "docs": {},
+                "k": {
+                  "df": 0,
+                  "docs": {},
+                  "e": {
+                    "df": 0,
+                    "docs": {},
+                    "n": {
+                      "df": 1,
+                      "docs": {
+                        "6": {
+                          "tf": 1.0
+                        }
+                      }
+                    }
+                  }
+                }
               }
             },
             "y": {
@@ -2497,7 +3126,7 @@
                 "e": {
                   "df": 1,
                   "docs": {
-                    "13": {
+                    "16": {
                       "tf": 1.7320508075688772
                     }
                   }
@@ -2515,7 +3144,7 @@
                 "e": {
                   "df": 1,
                   "docs": {
-                    "13": {
+                    "16": {
                       "tf": 1.0
                     }
                   },
@@ -2534,7 +3163,7 @@
                           "i": {
                             "df": 1,
                             "docs": {
-                              "13": {
+                              "16": {
                                 "tf": 1.0
                               }
                             }
@@ -2553,7 +3182,7 @@
                     "t": {
                       "df": 1,
                       "docs": {
-                        "12": {
+                        "15": {
                           "tf": 1.0
                         }
                       }
@@ -2565,9 +3194,12 @@
                 "df": 0,
                 "docs": {},
                 "s": {
-                  "df": 1,
+                  "df": 2,
                   "docs": {
                     "0": {
+                      "tf": 1.0
+                    },
+                    "6": {
                       "tf": 1.0
                     }
                   }
@@ -2590,10 +3222,10 @@
                       "df": 0,
                       "docs": {},
                       "r": {
-                        "df": 14,
+                        "df": 17,
                         "docs": {
                           "10": {
-                            "tf": 1.0
+                            "tf": 2.23606797749979
                           },
                           "11": {
                             "tf": 1.0
@@ -2605,12 +3237,21 @@
                             "tf": 1.0
                           },
                           "14": {
-                            "tf": 1.4142135623730951
+                            "tf": 1.0
                           },
                           "15": {
                             "tf": 1.0
                           },
                           "16": {
+                            "tf": 1.0
+                          },
+                          "17": {
+                            "tf": 1.4142135623730951
+                          },
+                          "18": {
+                            "tf": 1.0
+                          },
+                          "19": {
                             "tf": 1.0
                           },
                           "2": {
@@ -2626,7 +3267,7 @@
                             "tf": 1.0
                           },
                           "7": {
-                            "tf": 2.23606797749979
+                            "tf": 1.0
                           },
                           "8": {
                             "tf": 1.0
@@ -2647,7 +3288,7 @@
                       "t": {
                         "df": 1,
                         "docs": {
-                          "13": {
+                          "16": {
                             "tf": 2.23606797749979
                           }
                         }
@@ -2670,7 +3311,7 @@
                 "e": {
                   "df": 2,
                   "docs": {
-                    "14": {
+                    "17": {
                       "tf": 1.0
                     },
                     "4": {
@@ -2691,7 +3332,7 @@
                     "n": {
                       "df": 1,
                       "docs": {
-                        "13": {
+                        "16": {
                           "tf": 1.0
                         }
                       }
@@ -2699,7 +3340,27 @@
                   }
                 },
                 "df": 0,
-                "docs": {}
+                "docs": {},
+                "m": {
+                  "df": 0,
+                  "docs": {},
+                  "e": {
+                    "df": 0,
+                    "docs": {},
+                    "n": {
+                      "df": 0,
+                      "docs": {},
+                      "t": {
+                        "df": 1,
+                        "docs": {
+                          "6": {
+                            "tf": 1.4142135623730951
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
               },
               "n": {
                 "c": {
@@ -2714,11 +3375,11 @@
                       "s": {
                         "df": 2,
                         "docs": {
-                          "17": {
-                            "tf": 1.4142135623730951
-                          },
-                          "7": {
+                          "10": {
                             "tf": 1.0
+                          },
+                          "20": {
+                            "tf": 1.4142135623730951
                           }
                         }
                       }
@@ -2737,7 +3398,7 @@
                       "n": {
                         "df": 1,
                         "docs": {
-                          "13": {
+                          "16": {
                             "tf": 1.0
                           }
                         }
@@ -2745,7 +3406,23 @@
                     }
                   },
                   "df": 0,
-                  "docs": {}
+                  "docs": {},
+                  "e": {
+                    "df": 0,
+                    "docs": {},
+                    "n": {
+                      "df": 0,
+                      "docs": {},
+                      "t": {
+                        "df": 1,
+                        "docs": {
+                          "6": {
+                            "tf": 1.0
+                          }
+                        }
+                      }
+                    }
+                  }
                 }
               }
             },
@@ -2759,7 +3436,7 @@
                   "t": {
                     "df": 1,
                     "docs": {
-                      "13": {
+                      "16": {
                         "tf": 1.0
                       }
                     }
@@ -2773,7 +3450,7 @@
           "d": {
             "df": 1,
             "docs": {
-              "14": {
+              "17": {
                 "tf": 1.0
               }
             },
@@ -2792,7 +3469,7 @@
                       "0": {
                         "tf": 1.4142135623730951
                       },
-                      "7": {
+                      "10": {
                         "tf": 1.0
                       }
                     }
@@ -2813,7 +3490,7 @@
                 "t": {
                   "df": 1,
                   "docs": {
-                    "13": {
+                    "16": {
                       "tf": 1.0
                     }
                   }
@@ -2841,7 +3518,7 @@
                         "n": {
                           "df": 1,
                           "docs": {
-                            "13": {
+                            "16": {
                               "tf": 1.0
                             }
                           }
@@ -2863,7 +3540,7 @@
                 "n": {
                   "df": 1,
                   "docs": {
-                    "14": {
+                    "17": {
                       "tf": 1.0
                     }
                   }
@@ -2883,10 +3560,10 @@
                     "l": {
                       "df": 2,
                       "docs": {
-                        "10": {
+                        "13": {
                           "tf": 1.0
                         },
-                        "11": {
+                        "14": {
                           "tf": 1.0
                         }
                       }
@@ -2904,7 +3581,7 @@
                     "d": {
                       "df": 1,
                       "docs": {
-                        "14": {
+                        "17": {
                           "tf": 1.0
                         }
                       }
@@ -2919,8 +3596,48 @@
             }
           },
           "f": {
+            "a": {
+              "df": 0,
+              "docs": {},
+              "i": {
+                "df": 0,
+                "docs": {},
+                "l": {
+                  "df": 1,
+                  "docs": {
+                    "6": {
+                      "tf": 1.0
+                    }
+                  }
+                }
+              }
+            },
             "df": 0,
             "docs": {},
+            "e": {
+              "a": {
+                "df": 0,
+                "docs": {},
+                "t": {
+                  "df": 0,
+                  "docs": {},
+                  "u": {
+                    "df": 0,
+                    "docs": {},
+                    "r": {
+                      "df": 1,
+                      "docs": {
+                        "6": {
+                          "tf": 1.0
+                        }
+                      }
+                    }
+                  }
+                }
+              },
+              "df": 0,
+              "docs": {}
+            },
             "i": {
               "df": 0,
               "docs": {},
@@ -2928,16 +3645,22 @@
                 "df": 0,
                 "docs": {},
                 "e": {
-                  "df": 3,
+                  "df": 5,
                   "docs": {
                     "0": {
                       "tf": 1.0
                     },
-                    "14": {
+                    "17": {
                       "tf": 1.0
                     },
                     "4": {
                       "tf": 1.0
+                    },
+                    "6": {
+                      "tf": 1.4142135623730951
+                    },
+                    "7": {
+                      "tf": 1.4142135623730951
                     }
                   }
                 }
@@ -2949,10 +3672,10 @@
                   "df": 0,
                   "docs": {},
                   "t": {
-                    "df": 12,
+                    "df": 15,
                     "docs": {
                       "10": {
-                        "tf": 1.0
+                        "tf": 1.4142135623730951
                       },
                       "11": {
                         "tf": 1.0
@@ -2963,7 +3686,16 @@
                       "13": {
                         "tf": 1.0
                       },
+                      "14": {
+                        "tf": 1.0
+                      },
                       "15": {
+                        "tf": 1.0
+                      },
+                      "16": {
+                        "tf": 1.0
+                      },
+                      "18": {
                         "tf": 1.0
                       },
                       "2": {
@@ -2979,7 +3711,7 @@
                         "tf": 1.0
                       },
                       "7": {
-                        "tf": 1.4142135623730951
+                        "tf": 1.0
                       },
                       "8": {
                         "tf": 1.0
@@ -2993,10 +3725,16 @@
               }
             },
             "n": {
-              "df": 1,
+              "df": 3,
               "docs": {
-                "14": {
+                "17": {
                   "tf": 1.0
+                },
+                "7": {
+                  "tf": 1.4142135623730951
+                },
+                "8": {
+                  "tf": 1.4142135623730951
                 }
               }
             },
@@ -3006,7 +3744,7 @@
               "o": {
                 "df": 1,
                 "docs": {
-                  "9": {
+                  "12": {
                     "tf": 1.0
                   }
                 },
@@ -3022,7 +3760,7 @@
                       "t": {
                         "df": 1,
                         "docs": {
-                          "10": {
+                          "13": {
                             "tf": 2.23606797749979
                           }
                         }
@@ -3037,7 +3775,7 @@
                 "r": {
                   "df": 1,
                   "docs": {
-                    "13": {
+                    "16": {
                       "tf": 1.0
                     }
                   }
@@ -3063,7 +3801,7 @@
                         "t": {
                           "df": 1,
                           "docs": {
-                            "15": {
+                            "18": {
                               "tf": 1.0
                             }
                           }
@@ -3112,7 +3850,7 @@
                   "o": {
                     "df": 1,
                     "docs": {
-                      "13": {
+                      "16": {
                         "tf": 1.0
                       }
                     }
@@ -3136,7 +3874,7 @@
                     "0": {
                       "tf": 1.0
                     },
-                    "17": {
+                    "20": {
                       "tf": 1.0
                     }
                   }
@@ -3152,10 +3890,13 @@
                     "df": 0,
                     "docs": {},
                     "n": {
-                      "df": 1,
+                      "df": 2,
                       "docs": {
-                        "14": {
+                        "17": {
                           "tf": 1.0
+                        },
+                        "7": {
+                          "tf": 1.4142135623730951
                         }
                       }
                     }
@@ -3166,7 +3907,7 @@
                 "e": {
                   "df": 1,
                   "docs": {
-                    "14": {
+                    "17": {
                       "tf": 1.0
                     }
                   }
@@ -3184,7 +3925,7 @@
                 "l": {
                   "df": 1,
                   "docs": {
-                    "15": {
+                    "18": {
                       "tf": 1.0
                     }
                   }
@@ -3202,7 +3943,7 @@
                 "g": {
                   "df": 1,
                   "docs": {
-                    "15": {
+                    "18": {
                       "tf": 1.0
                     }
                   }
@@ -3220,13 +3961,22 @@
                   "docs": {},
                   "u": {
                     "d": {
-                      "df": 2,
+                      "df": 5,
                       "docs": {
+                        "10": {
+                          "tf": 1.0
+                        },
                         "6": {
-                          "tf": 1.4142135623730951
+                          "tf": 1.7320508075688772
                         },
                         "7": {
-                          "tf": 1.0
+                          "tf": 1.4142135623730951
+                        },
+                        "8": {
+                          "tf": 1.4142135623730951
+                        },
+                        "9": {
+                          "tf": 1.4142135623730951
                         }
                       }
                     },
@@ -3265,7 +4015,7 @@
                     "t": {
                       "df": 1,
                       "docs": {
-                        "14": {
+                        "17": {
                           "tf": 1.0
                         }
                       }
@@ -3317,7 +4067,7 @@
                               "1": {
                                 "tf": 1.4142135623730951
                               },
-                              "7": {
+                              "10": {
                                 "tf": 1.0
                               }
                             }
@@ -3331,6 +4081,26 @@
                     "docs": {}
                   }
                 }
+              }
+            },
+            "s": {
+              "df": 0,
+              "docs": {},
+              "n": {
+                "'": {
+                  "df": 0,
+                  "docs": {},
+                  "t": {
+                    "df": 1,
+                    "docs": {
+                      "6": {
+                        "tf": 1.0
+                      }
+                    }
+                  }
+                },
+                "df": 0,
+                "docs": {}
               }
             }
           },
@@ -3362,7 +4132,7 @@
                 "t": {
                   "df": 1,
                   "docs": {
-                    "13": {
+                    "16": {
                       "tf": 1.4142135623730951
                     }
                   }
@@ -3376,12 +4146,15 @@
                 "df": 0,
                 "docs": {},
                 "e": {
-                  "df": 2,
+                  "df": 3,
                   "docs": {
-                    "10": {
+                    "13": {
                       "tf": 1.4142135623730951
                     },
-                    "14": {
+                    "17": {
+                      "tf": 1.0
+                    },
+                    "6": {
                       "tf": 1.0
                     }
                   }
@@ -3389,7 +4162,7 @@
                 "k": {
                   "df": 1,
                   "docs": {
-                    "15": {
+                    "18": {
                       "tf": 2.449489742783178
                     }
                   }
@@ -3411,7 +4184,7 @@
                     "r": {
                       "df": 1,
                       "docs": {
-                        "10": {
+                        "13": {
                           "tf": 1.0
                         }
                       }
@@ -3443,7 +4216,7 @@
                             "t": {
                               "df": 1,
                               "docs": {
-                                "17": {
+                                "20": {
                                   "tf": 1.0
                                 }
                               }
@@ -3469,9 +4242,15 @@
                 "df": 0,
                 "docs": {},
                 "n": {
-                  "df": 1,
+                  "df": 3,
                   "docs": {
-                    "14": {
+                    "17": {
+                      "tf": 1.0
+                    },
+                    "7": {
+                      "tf": 1.0
+                    },
+                    "8": {
                       "tf": 1.0
                     }
                   }
@@ -3483,7 +4262,7 @@
                 "e": {
                   "df": 1,
                   "docs": {
-                    "14": {
+                    "17": {
                       "tf": 1.0
                     }
                   }
@@ -3505,10 +4284,10 @@
                         "n": {
                           "df": 2,
                           "docs": {
-                            "7": {
+                            "10": {
                               "tf": 1.0
                             },
-                            "8": {
+                            "11": {
                               "tf": 1.7320508075688772
                             }
                           }
@@ -3518,7 +4297,7 @@
                   },
                   "df": 1,
                   "docs": {
-                    "13": {
+                    "16": {
                       "tf": 1.0
                     }
                   }
@@ -3561,7 +4340,7 @@
                       "l": {
                         "df": 1,
                         "docs": {
-                          "10": {
+                          "13": {
                             "tf": 1.0
                           }
                         }
@@ -3584,11 +4363,23 @@
                 "t": {
                   "df": 2,
                   "docs": {
-                    "4": {
+                    "10": {
                       "tf": 1.4142135623730951
                     },
-                    "7": {
+                    "4": {
                       "tf": 1.4142135623730951
+                    }
+                  }
+                }
+              },
+              "x": {
+                "df": 0,
+                "docs": {},
+                "t": {
+                  "df": 1,
+                  "docs": {
+                    "6": {
+                      "tf": 1.0
                     }
                   }
                 }
@@ -3600,7 +4391,7 @@
               "n": {
                 "df": 1,
                 "docs": {
-                  "15": {
+                  "18": {
                     "tf": 1.0
                   }
                 }
@@ -3625,7 +4416,7 @@
                     "t": {
                       "df": 1,
                       "docs": {
-                        "8": {
+                        "11": {
                           "tf": 1.0
                         }
                       }
@@ -3639,7 +4430,7 @@
                     "d": {
                       "df": 1,
                       "docs": {
-                        "15": {
+                        "18": {
                           "tf": 1.0
                         }
                       }
@@ -3661,8 +4452,20 @@
                 "e": {
                   "df": 1,
                   "docs": {
-                    "15": {
+                    "18": {
                       "tf": 2.0
+                    }
+                  }
+                }
+              },
+              "r": {
+                "df": 0,
+                "docs": {},
+                "t": {
+                  "df": 1,
+                  "docs": {
+                    "6": {
+                      "tf": 1.4142135623730951
                     }
                   }
                 }
@@ -3680,7 +4483,7 @@
                   "s": {
                     "df": 1,
                     "docs": {
-                      "13": {
+                      "16": {
                         "tf": 1.0
                       }
                     }
@@ -3762,7 +4565,7 @@
                   "t": {
                     "df": 1,
                     "docs": {
-                      "15": {
+                      "18": {
                         "tf": 2.0
                       }
                     },
@@ -3790,7 +4593,7 @@
                                       "o": {
                                         "df": 1,
                                         "docs": {
-                                          "14": {
+                                          "17": {
                                             "tf": 1.0
                                           }
                                         }
@@ -3802,7 +4605,7 @@
                               "i": {
                                 "df": 1,
                                 "docs": {
-                                  "14": {
+                                  "17": {
                                     "tf": 1.0
                                   }
                                 }
@@ -3828,7 +4631,7 @@
               "t": {
                 "df": 1,
                 "docs": {
-                  "17": {
+                  "20": {
                     "tf": 1.0
                   }
                 }
@@ -3851,7 +4654,7 @@
                     "s": {
                       "df": 1,
                       "docs": {
-                        "7": {
+                        "10": {
                           "tf": 1.0
                         }
                       }
@@ -3864,8 +4667,76 @@
               "l": {
                 "df": 1,
                 "docs": {
-                  "15": {
+                  "18": {
                     "tf": 1.4142135623730951
+                  }
+                }
+              },
+              "n": {
+                "d": {
+                  "df": 0,
+                  "docs": {},
+                  "e": {
+                    "df": 0,
+                    "docs": {},
+                    "r": {
+                      "df": 0,
+                      "docs": {},
+                      "e": {
+                        "d": {
+                          "_": {
+                            "df": 0,
+                            "docs": {},
+                            "o": {
+                              "df": 0,
+                              "docs": {},
+                              "u": {
+                                "df": 0,
+                                "docs": {},
+                                "t": {
+                                  "df": 0,
+                                  "docs": {},
+                                  "p": {
+                                    "df": 0,
+                                    "docs": {},
+                                    "u": {
+                                      "df": 0,
+                                      "docs": {},
+                                      "t": {
+                                        "df": 1,
+                                        "docs": {
+                                          "6": {
+                                            "tf": 1.0
+                                          }
+                                        }
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          },
+                          "df": 0,
+                          "docs": {}
+                        },
+                        "df": 0,
+                        "docs": {}
+                      }
+                    }
+                  }
+                },
+                "df": 0,
+                "docs": {}
+              },
+              "s": {
+                "df": 0,
+                "docs": {},
+                "t": {
+                  "df": 1,
+                  "docs": {
+                    "7": {
+                      "tf": 1.4142135623730951
+                    }
                   }
                 }
               }
@@ -3882,7 +4753,7 @@
                   "t": {
                     "df": 1,
                     "docs": {
-                      "13": {
+                      "16": {
                         "tf": 1.4142135623730951
                       }
                     }
@@ -3908,7 +4779,7 @@
                       "l": {
                         "df": 1,
                         "docs": {
-                          "14": {
+                          "17": {
                             "tf": 1.0
                           }
                         }
@@ -3925,9 +4796,28 @@
                 "df": 0,
                 "docs": {},
                 "t": {
+                  "d": {
+                    "df": 0,
+                    "docs": {},
+                    "o": {
+                      "c": {
+                        "df": 2,
+                        "docs": {
+                          "7": {
+                            "tf": 1.4142135623730951
+                          },
+                          "8": {
+                            "tf": 1.4142135623730951
+                          }
+                        }
+                      },
+                      "df": 0,
+                      "docs": {}
+                    }
+                  },
                   "df": 1,
                   "docs": {
-                    "14": {
+                    "17": {
                       "tf": 1.0
                     }
                   }
@@ -3949,16 +4839,16 @@
                     "d": {
                       "df": 4,
                       "docs": {
-                        "14": {
+                        "10": {
+                          "tf": 1.0
+                        },
+                        "17": {
                           "tf": 1.4142135623730951
                         },
-                        "15": {
+                        "18": {
                           "tf": 1.0
                         },
-                        "16": {
-                          "tf": 1.0
-                        },
-                        "7": {
+                        "19": {
                           "tf": 1.0
                         }
                       }
@@ -3979,10 +4869,10 @@
                       "n": {
                         "df": 4,
                         "docs": {
-                          "15": {
+                          "18": {
                             "tf": 1.0
                           },
-                          "16": {
+                          "19": {
                             "tf": 1.4142135623730951
                           },
                           "3": {
@@ -4002,7 +4892,7 @@
               "e": {
                 "df": 1,
                 "docs": {
-                  "14": {
+                  "17": {
                     "tf": 1.0
                   }
                 }
@@ -4026,13 +4916,101 @@
                       "t": {
                         "df": 1,
                         "docs": {
-                          "14": {
+                          "17": {
                             "tf": 1.0
                           }
                         }
                       }
                     }
                   }
+                }
+              }
+            },
+            "o": {
+              "df": 0,
+              "docs": {},
+              "m": {
+                "df": 0,
+                "docs": {},
+                "e": {
+                  "_": {
+                    "df": 0,
+                    "docs": {},
+                    "f": {
+                      "df": 0,
+                      "docs": {},
+                      "u": {
+                        "df": 0,
+                        "docs": {},
+                        "n": {
+                          "c": {
+                            "df": 0,
+                            "docs": {},
+                            "t": {
+                              "df": 1,
+                              "docs": {
+                                "7": {
+                                  "tf": 1.4142135623730951
+                                }
+                              }
+                            }
+                          },
+                          "df": 0,
+                          "docs": {}
+                        }
+                      }
+                    },
+                    "o": {
+                      "df": 0,
+                      "docs": {},
+                      "t": {
+                        "df": 0,
+                        "docs": {},
+                        "h": {
+                          "df": 0,
+                          "docs": {},
+                          "e": {
+                            "df": 0,
+                            "docs": {},
+                            "r": {
+                              "_": {
+                                "df": 0,
+                                "docs": {},
+                                "f": {
+                                  "df": 0,
+                                  "docs": {},
+                                  "u": {
+                                    "df": 0,
+                                    "docs": {},
+                                    "n": {
+                                      "c": {
+                                        "df": 0,
+                                        "docs": {},
+                                        "t": {
+                                          "df": 1,
+                                          "docs": {
+                                            "8": {
+                                              "tf": 1.4142135623730951
+                                            }
+                                          }
+                                        }
+                                      },
+                                      "df": 0,
+                                      "docs": {}
+                                    }
+                                  }
+                                }
+                              },
+                              "df": 0,
+                              "docs": {}
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "df": 0,
+                  "docs": {}
                 }
               }
             },
@@ -4055,7 +5033,7 @@
                         "r": {
                           "df": 1,
                           "docs": {
-                            "13": {
+                            "16": {
                               "tf": 1.0
                             }
                           }
@@ -4068,7 +5046,7 @@
                       "r": {
                         "df": 1,
                         "docs": {
-                          "13": {
+                          "16": {
                             "tf": 1.0
                           }
                         }
@@ -4078,7 +5056,31 @@
                 }
               },
               "df": 0,
-              "docs": {}
+              "docs": {},
+              "e": {
+                "c": {
+                  "df": 0,
+                  "docs": {},
+                  "i": {
+                    "a": {
+                      "df": 0,
+                      "docs": {},
+                      "l": {
+                        "df": 1,
+                        "docs": {
+                          "6": {
+                            "tf": 1.4142135623730951
+                          }
+                        }
+                      }
+                    },
+                    "df": 0,
+                    "docs": {}
+                  }
+                },
+                "df": 0,
+                "docs": {}
+              }
             },
             "t": {
               "df": 0,
@@ -4095,7 +5097,7 @@
                     "s": {
                       "df": 1,
                       "docs": {
-                        "13": {
+                        "16": {
                           "tf": 1.4142135623730951
                         }
                       }
@@ -4132,7 +5134,7 @@
                                   "h": {
                                     "df": 1,
                                     "docs": {
-                                      "11": {
+                                      "14": {
                                         "tf": 1.7320508075688772
                                       }
                                     }
@@ -4144,11 +5146,35 @@
                         }
                       }
                     }
+                  },
+                  "n": {
+                    "df": 0,
+                    "docs": {},
+                    "g": {
+                      "df": 1,
+                      "docs": {
+                        "6": {
+                          "tf": 1.0
+                        }
+                      }
+                    }
                   }
                 }
               }
             },
             "u": {
+              "c": {
+                "df": 0,
+                "docs": {},
+                "h": {
+                  "df": 1,
+                  "docs": {
+                    "6": {
+                      "tf": 1.0
+                    }
+                  }
+                }
+              },
               "df": 0,
               "docs": {},
               "m": {
@@ -4164,7 +5190,7 @@
                       "i": {
                         "df": 1,
                         "docs": {
-                          "7": {
+                          "10": {
                             "tf": 1.4142135623730951
                           }
                         }
@@ -4181,7 +5207,7 @@
                 "e": {
                   "df": 1,
                   "docs": {
-                    "14": {
+                    "17": {
                       "tf": 1.0
                     }
                   }
@@ -4197,7 +5223,7 @@
                 "l": {
                   "df": 1,
                   "docs": {
-                    "9": {
+                    "12": {
                       "tf": 1.4142135623730951
                     }
                   }
@@ -4223,7 +5249,7 @@
                         "k": {
                           "df": 1,
                           "docs": {
-                            "12": {
+                            "15": {
                               "tf": 1.4142135623730951
                             }
                           }
@@ -4259,16 +5285,19 @@
                     "df": 0,
                     "docs": {}
                   },
-                  "df": 3,
+                  "df": 4,
                   "docs": {
-                    "13": {
-                      "tf": 1.4142135623730951
-                    },
-                    "15": {
-                      "tf": 1.4142135623730951
-                    },
-                    "8": {
+                    "11": {
                       "tf": 1.7320508075688772
+                    },
+                    "16": {
+                      "tf": 1.4142135623730951
+                    },
+                    "18": {
+                      "tf": 1.4142135623730951
+                    },
+                    "6": {
+                      "tf": 1.4142135623730951
                     }
                   }
                 }
@@ -4299,7 +5328,7 @@
                   "d": {
                     "df": 1,
                     "docs": {
-                      "10": {
+                      "13": {
                         "tf": 1.0
                       }
                     }
@@ -4317,7 +5346,7 @@
                   "e": {
                     "df": 1,
                     "docs": {
-                      "13": {
+                      "16": {
                         "tf": 1.0
                       }
                     }
@@ -4331,7 +5360,7 @@
               "o": {
                 "df": 1,
                 "docs": {
-                  "13": {
+                  "16": {
                     "tf": 1.0
                   }
                 }
@@ -4352,11 +5381,11 @@
                     "d": {
                       "df": 2,
                       "docs": {
-                        "13": {
-                          "tf": 1.4142135623730951
-                        },
-                        "7": {
+                        "10": {
                           "tf": 1.0
+                        },
+                        "16": {
+                          "tf": 1.4142135623730951
                         }
                       }
                     },
@@ -4365,11 +5394,35 @@
                   }
                 },
                 "df": 0,
-                "docs": {}
+                "docs": {},
+                "q": {
+                  "df": 0,
+                  "docs": {},
+                  "u": {
+                    "df": 1,
+                    "docs": {
+                      "6": {
+                        "tf": 1.0
+                      }
+                    }
+                  }
+                }
               }
             }
           },
           "w": {
+            "a": {
+              "df": 0,
+              "docs": {},
+              "y": {
+                "df": 1,
+                "docs": {
+                  "6": {
+                    "tf": 1.0
+                  }
+                }
+              }
+            },
             "df": 0,
             "docs": {},
             "o": {
@@ -4379,7 +5432,7 @@
                 "d": {
                   "df": 1,
                   "docs": {
-                    "10": {
+                    "13": {
                       "tf": 1.0
                     }
                   }
@@ -4387,9 +5440,12 @@
                 "df": 0,
                 "docs": {},
                 "k": {
-                  "df": 1,
+                  "df": 2,
                   "docs": {
-                    "15": {
+                    "18": {
+                      "tf": 1.4142135623730951
+                    },
+                    "8": {
                       "tf": 1.4142135623730951
                     }
                   }
@@ -4398,7 +5454,7 @@
                   "d": {
                     "df": 1,
                     "docs": {
-                      "14": {
+                      "17": {
                         "tf": 1.0
                       }
                     }
@@ -4422,7 +5478,7 @@
                   "o": {
                     "df": 1,
                     "docs": {
-                      "13": {
+                      "16": {
                         "tf": 1.0
                       }
                     }
@@ -4437,9 +5493,80 @@
       },
       "title": {
         "root": {
+          "a": {
+            "d": {
+              "d": {
+                "df": 1,
+                "docs": {
+                  "7": {
+                    "tf": 1.0
+                  }
+                }
+              },
+              "df": 0,
+              "docs": {}
+            },
+            "df": 0,
+            "docs": {},
+            "n": {
+              "c": {
+                "df": 0,
+                "docs": {},
+                "h": {
+                  "df": 0,
+                  "docs": {},
+                  "o": {
+                    "df": 0,
+                    "docs": {},
+                    "r": {
+                      "df": 2,
+                      "docs": {
+                        "6": {
+                          "tf": 1.0
+                        },
+                        "8": {
+                          "tf": 1.0
+                        }
+                      }
+                    }
+                  }
+                }
+              },
+              "df": 0,
+              "docs": {}
+            }
+          },
           "b": {
             "df": 0,
             "docs": {},
+            "e": {
+              "df": 0,
+              "docs": {},
+              "t": {
+                "df": 0,
+                "docs": {},
+                "w": {
+                  "df": 0,
+                  "docs": {},
+                  "e": {
+                    "df": 0,
+                    "docs": {},
+                    "e": {
+                      "df": 0,
+                      "docs": {},
+                      "n": {
+                        "df": 1,
+                        "docs": {
+                          "6": {
+                            "tf": 1.0
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
             "o": {
               "df": 0,
               "docs": {},
@@ -4476,7 +5603,7 @@
                       "r": {
                         "df": 3,
                         "docs": {
-                          "14": {
+                          "17": {
                             "tf": 1.0
                           },
                           "2": {
@@ -4497,6 +5624,30 @@
             "o": {
               "df": 0,
               "docs": {},
+              "m": {
+                "df": 0,
+                "docs": {},
+                "m": {
+                  "df": 0,
+                  "docs": {},
+                  "e": {
+                    "df": 0,
+                    "docs": {},
+                    "n": {
+                      "df": 0,
+                      "docs": {},
+                      "t": {
+                        "df": 1,
+                        "docs": {
+                          "6": {
+                            "tf": 1.0
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              },
               "n": {
                 "c": {
                   "df": 0,
@@ -4510,7 +5661,7 @@
                       "s": {
                         "df": 1,
                         "docs": {
-                          "17": {
+                          "20": {
                             "tf": 1.0
                           }
                         }
@@ -4555,6 +5706,21 @@
             "i": {
               "df": 0,
               "docs": {},
+              "l": {
+                "df": 0,
+                "docs": {},
+                "e": {
+                  "df": 2,
+                  "docs": {
+                    "6": {
+                      "tf": 1.0
+                    },
+                    "7": {
+                      "tf": 1.0
+                    }
+                  }
+                }
+              },
               "r": {
                 "df": 0,
                 "docs": {},
@@ -4590,7 +5756,7 @@
                       "t": {
                         "df": 1,
                         "docs": {
-                          "10": {
+                          "13": {
                             "tf": 1.0
                           }
                         }
@@ -4599,6 +5765,34 @@
                   }
                 }
               }
+            }
+          },
+          "h": {
+            "df": 0,
+            "docs": {},
+            "i": {
+              "d": {
+                "d": {
+                  "df": 0,
+                  "docs": {},
+                  "e": {
+                    "df": 0,
+                    "docs": {},
+                    "n": {
+                      "df": 1,
+                      "docs": {
+                        "7": {
+                          "tf": 1.0
+                        }
+                      }
+                    }
+                  }
+                },
+                "df": 0,
+                "docs": {}
+              },
+              "df": 0,
+              "docs": {}
             }
           },
           "i": {
@@ -4613,9 +5807,18 @@
                   "docs": {},
                   "u": {
                     "d": {
-                      "df": 1,
+                      "df": 4,
                       "docs": {
                         "6": {
+                          "tf": 1.0
+                        },
+                        "7": {
+                          "tf": 1.0
+                        },
+                        "8": {
+                          "tf": 1.0
+                        },
+                        "9": {
                           "tf": 1.0
                         }
                       }
@@ -4673,7 +5876,7 @@
                 "k": {
                   "df": 1,
                   "docs": {
-                    "15": {
+                    "18": {
                       "tf": 1.0
                     }
                   }
@@ -4701,7 +5904,7 @@
                         "n": {
                           "df": 1,
                           "docs": {
-                            "8": {
+                            "11": {
                               "tf": 1.0
                             }
                           }
@@ -4747,7 +5950,19 @@
                 "e": {
                   "df": 1,
                   "docs": {
-                    "15": {
+                    "18": {
+                      "tf": 1.0
+                    }
+                  }
+                }
+              },
+              "r": {
+                "df": 0,
+                "docs": {},
+                "t": {
+                  "df": 1,
+                  "docs": {
+                    "6": {
                       "tf": 1.0
                     }
                   }
@@ -4768,7 +5983,7 @@
                   "t": {
                     "df": 1,
                     "docs": {
-                      "15": {
+                      "18": {
                         "tf": 1.0
                       }
                     }
@@ -4786,9 +6001,52 @@
               "l": {
                 "df": 1,
                 "docs": {
-                  "15": {
+                  "18": {
                     "tf": 1.0
                   }
+                }
+              },
+              "s": {
+                "df": 0,
+                "docs": {},
+                "t": {
+                  "df": 1,
+                  "docs": {
+                    "7": {
+                      "tf": 1.0
+                    }
+                  }
+                }
+              }
+            },
+            "u": {
+              "df": 0,
+              "docs": {},
+              "s": {
+                "df": 0,
+                "docs": {},
+                "t": {
+                  "d": {
+                    "df": 0,
+                    "docs": {},
+                    "o": {
+                      "c": {
+                        "df": 2,
+                        "docs": {
+                          "7": {
+                            "tf": 1.0
+                          },
+                          "8": {
+                            "tf": 1.0
+                          }
+                        }
+                      },
+                      "df": 0,
+                      "docs": {}
+                    }
+                  },
+                  "df": 0,
+                  "docs": {}
                 }
               }
             }
@@ -4807,7 +6065,7 @@
                     "d": {
                       "df": 1,
                       "docs": {
-                        "14": {
+                        "17": {
                           "tf": 1.0
                         }
                       }
@@ -4828,7 +6086,7 @@
                       "n": {
                         "df": 3,
                         "docs": {
-                          "16": {
+                          "19": {
                             "tf": 1.0
                           },
                           "3": {
@@ -4846,6 +6104,34 @@
               "df": 0,
               "docs": {}
             },
+            "p": {
+              "df": 0,
+              "docs": {},
+              "e": {
+                "c": {
+                  "df": 0,
+                  "docs": {},
+                  "i": {
+                    "a": {
+                      "df": 0,
+                      "docs": {},
+                      "l": {
+                        "df": 1,
+                        "docs": {
+                          "6": {
+                            "tf": 1.0
+                          }
+                        }
+                      }
+                    },
+                    "df": 0,
+                    "docs": {}
+                  }
+                },
+                "df": 0,
+                "docs": {}
+              }
+            },
             "t": {
               "df": 0,
               "docs": {},
@@ -4861,7 +6147,7 @@
                     "s": {
                       "df": 1,
                       "docs": {
-                        "13": {
+                        "16": {
                           "tf": 1.0
                         }
                       }
@@ -4898,7 +6184,7 @@
                                   "h": {
                                     "df": 1,
                                     "docs": {
-                                      "11": {
+                                      "14": {
                                         "tf": 1.0
                                       }
                                     }
@@ -4930,7 +6216,7 @@
                       "i": {
                         "df": 1,
                         "docs": {
-                          "7": {
+                          "10": {
                             "tf": 1.0
                           }
                         }
@@ -4951,7 +6237,7 @@
                 "l": {
                   "df": 1,
                   "docs": {
-                    "9": {
+                    "12": {
                       "tf": 1.0
                     }
                   }
@@ -4977,7 +6263,7 @@
                         "k": {
                           "df": 1,
                           "docs": {
-                            "12": {
+                            "15": {
                               "tf": 1.0
                             }
                           }
@@ -4999,13 +6285,13 @@
                 "t": {
                   "df": 3,
                   "docs": {
-                    "13": {
+                    "11": {
                       "tf": 1.0
                     },
-                    "15": {
+                    "16": {
                       "tf": 1.0
                     },
-                    "8": {
+                    "18": {
                       "tf": 1.0
                     }
                   }
@@ -5027,7 +6313,7 @@
                     "d": {
                       "df": 1,
                       "docs": {
-                        "13": {
+                        "16": {
                           "tf": 1.0
                         }
                       }
@@ -5038,6 +6324,26 @@
                 },
                 "df": 0,
                 "docs": {}
+              }
+            }
+          },
+          "w": {
+            "df": 0,
+            "docs": {},
+            "o": {
+              "df": 0,
+              "docs": {},
+              "r": {
+                "df": 0,
+                "docs": {},
+                "k": {
+                  "df": 1,
+                  "docs": {
+                    "8": {
+                      "tf": 1.0
+                    }
+                  }
+                }
               }
             }
           }


### PR DESCRIPTION
Fixes #618 

This would make work on The Book to extract code listings into external, complete, testable examples easier.

I'm going to mostly let the documentation speak for itself; if it doesn't completely explain this feature, I'd like to fix it!

I'm also totally open to a different name for this feature 🤷‍♀ 	