### PR TITLE
Fix "next" navigation on index.html (take 2).

### DIFF
--- a/src/renderer/html_handlebars/hbs_renderer.rs
+++ b/src/renderer/html_handlebars/hbs_renderer.rs
@@ -85,6 +85,7 @@ impl HtmlHandlebars {
             if ctx.is_index {
                 ctx.data.insert("path".to_owned(), json!("index.md"));
                 ctx.data.insert("path_to_root".to_owned(), json!(""));
+                ctx.data.insert("is_index".to_owned(), json!("true"));
                 let rendered_index = ctx.handlebars.render("index", &ctx.data)?;
                 let rendered_index = self.post_process(rendered_index, &ctx.html_config.playpen);
                 debug!("Creating index.html from {}", path);

--- a/src/renderer/html_handlebars/helpers/navigation.rs
+++ b/src/renderer/html_handlebars/helpers/navigation.rs
@@ -63,6 +63,19 @@ fn find_chapter(
         .ok_or_else(|| RenderError::new("Type error for `path`, string expected"))?
         .replace("\"", "");
 
+    if !rc.evaluate(ctx, "@root/is_index")?.is_missing() {
+        // Special case for index.md which may be a synthetic page.
+        // Target::find won't match because there is no page with the path
+        // "index.md" (unless there really is an index.md in SUMMARY.md).
+        match target {
+            Target::Previous => return Ok(None),
+            Target::Next => match chapters.iter().skip(1).next() {
+                Some(chapter) => return Ok(Some(chapter.clone())),
+                None => return Ok(None),
+            },
+        }
+    }
+
     let mut previous: Option<StringMap> = None;
 
     debug!("Search for chapter");


### PR DESCRIPTION
Actual fix for "next" link on index.html.

The previous fix (#916) was not sufficient, I'm not sure what happened.  `Target::find` would never match "index.md" because that page does not exist in the chapters list.

Fixes #874.