### PR TITLE
[Feature] expandable sidebar sections (ToC collapse)

### DIFF
--- a/book-example/src/format/config.md
+++ b/book-example/src/format/config.md
@@ -166,6 +166,7 @@ The following configuration options are available:
 - **no-section-label:** mdBook by defaults adds section label in table of
   contents column. For example, "1.", "2.1". Set this option to true to disable
   those labels. Defaults to `false`.
+- **fold:** A subtable for configuring sidebar section-folding behavior.
 - **playpen:** A subtable for configuring various playpen settings.
 - **search:** A subtable for configuring the in-browser search functionality.
   mdBook must be compiled with the `search` feature enabled (on by default).
@@ -173,6 +174,13 @@ The following configuration options are available:
   an icon link will be output in the menu bar of the book.
 - **git-repository-icon:** The FontAwesome icon class to use for the git
   repository link. Defaults to `fa-github`.
+  
+Available configuration options for the `[output.html.fold]` table:
+
+- **enable:** Enable section-folding. When off, all folds are open.
+  Defaults to `false`.
+- **level:** The higher the more folded regions are open. When level is 0, all
+  folds are closed. Defaults to `0`.
 
 Available configuration options for the `[output.html.playpen]` table:
 
@@ -224,6 +232,10 @@ additional-js = ["custom.js"]
 no-section-label = false
 git-repository-url = "https://github.com/rust-lang-nursery/mdBook"
 git-repository-icon = "fa-github"
+
+[output.html.fold]
+enable = false
+level = 0
 
 [output.html.playpen]
 editable = false

--- a/src/config.rs
+++ b/src/config.rs
@@ -431,16 +431,10 @@ pub struct HtmlConfig {
     /// Additional JS scripts to include at the bottom of the rendered page's
     /// `<body>`.
     pub additional_js: Vec<PathBuf>,
+    /// Fold settings.
+    pub fold: Fold,
     /// Playpen settings.
     pub playpen: Playpen,
-    /// This is used as a bit of a workaround for the `mdbook serve` command.
-    /// Basically, because you set the websocket port from the command line, the
-    /// `mdbook serve` command needs a way to let the HTML renderer know where
-    /// to point livereloading at, if it has been enabled.
-    ///
-    /// This config item *should not be edited* by the end user.
-    #[doc(hidden)]
-    pub livereload_url: Option<String>,
     /// Don't render section labels.
     pub no_section_label: bool,
     /// Search settings. If `None`, the default will be used.
@@ -450,6 +444,14 @@ pub struct HtmlConfig {
     /// FontAwesome icon class to use for the Git repository link.
     /// Defaults to `fa-github` if `None`.
     pub git_repository_icon: Option<String>,
+    /// This is used as a bit of a workaround for the `mdbook serve` command.
+    /// Basically, because you set the websocket port from the command line, the
+    /// `mdbook serve` command needs a way to let the HTML renderer know where
+    /// to point livereloading at, if it has been enabled.
+    ///
+    /// This config item *should not be edited* by the end user.
+    #[doc(hidden)]
+    pub livereload_url: Option<String>,
 }
 
 impl HtmlConfig {
@@ -459,6 +461,27 @@ impl HtmlConfig {
         match self.theme {
             Some(ref d) => root.join(d),
             None => root.join("theme"),
+        }
+    }
+}
+
+/// Configuration for how to fold chapters of sidebar.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(default, rename_all = "kebab-case")]
+pub struct Fold {
+    /// When off, all folds are open. Default: `false`.
+    pub enable: bool,
+    /// The higher the more folded regions are open. When level is 0, all folds
+    /// are closed.
+    /// Default: `0`.
+    pub level: u8,
+}
+
+impl Default for Fold {
+    fn default() -> Self {
+        Self {
+            enable: false,
+            level: 0,
         }
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -466,7 +466,7 @@ impl HtmlConfig {
 }
 
 /// Configuration for how to fold chapters of sidebar.
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(default, rename_all = "kebab-case")]
 pub struct Fold {
     /// When off, all folds are open. Default: `false`.
@@ -475,15 +475,6 @@ pub struct Fold {
     /// are closed.
     /// Default: `0`.
     pub level: u8,
-}
-
-impl Default for Fold {
-    fn default() -> Self {
-        Self {
-            enable: false,
-            level: 0,
-        }
-    }
 }
 
 /// Configuration for tweaking how the the HTML renderer handles the playpen.

--- a/src/renderer/html_handlebars/hbs_renderer.rs
+++ b/src/renderer/html_handlebars/hbs_renderer.rs
@@ -448,6 +448,9 @@ fn make_data(
         data.insert("playpen_js".to_owned(), json!(true));
     }
 
+    data.insert("fold_enable".to_owned(), json!((html_config.fold.enable)));
+    data.insert("fold_level".to_owned(), json!((html_config.fold.level)));
+
     let search = html_config.search.clone();
     if cfg!(feature = "search") {
         let search = search.unwrap_or_default();
@@ -467,6 +470,7 @@ fn make_data(
     if let Some(ref git_repository_url) = html_config.git_repository_url {
         data.insert("git_repository_url".to_owned(), json!(git_repository_url));
     }
+
     let git_repository_icon = match html_config.git_repository_icon {
         Some(ref git_repository_icon) => git_repository_icon,
         None => "fa-github",
@@ -486,8 +490,8 @@ fn make_data(
                 }
 
                 chapter.insert(
-                    "sub_items_count".to_owned(),
-                    json!(ch.sub_items.len().to_string()),
+                    "has_sub_items".to_owned(),
+                    json!((ch.sub_items.len() > 0).to_string()),
                 );
 
                 chapter.insert("name".to_owned(), json!(ch.name));

--- a/src/renderer/html_handlebars/hbs_renderer.rs
+++ b/src/renderer/html_handlebars/hbs_renderer.rs
@@ -71,6 +71,10 @@ impl HtmlHandlebars {
                 "path_to_root".to_owned(),
                 json!(utils::fs::path_to_root(&ch.path)),
             );
+            if let Some(ref section) = ch.number {
+                ctx.data
+                    .insert("section".to_owned(), json!(section.to_string()));
+            }
 
             // Render the handlebars template with the data
             debug!("Render template");
@@ -480,6 +484,11 @@ fn make_data(
                 if let Some(ref section) = ch.number {
                     chapter.insert("section".to_owned(), json!(section.to_string()));
                 }
+
+                chapter.insert(
+                    "sub_items_count".to_owned(),
+                    json!(ch.sub_items.len().to_string()),
+                );
 
                 chapter.insert("name".to_owned(), json!(ch.name));
                 let path = ch

--- a/src/renderer/html_handlebars/hbs_renderer.rs
+++ b/src/renderer/html_handlebars/hbs_renderer.rs
@@ -491,7 +491,7 @@ fn make_data(
 
                 chapter.insert(
                     "has_sub_items".to_owned(),
-                    json!((ch.sub_items.len() > 0).to_string()),
+                    json!((!ch.sub_items.is_empty()).to_string()),
                 );
 
                 chapter.insert("name".to_owned(), json!(ch.name));

--- a/src/renderer/html_handlebars/helpers/toc.rs
+++ b/src/renderer/html_handlebars/helpers/toc.rs
@@ -84,7 +84,7 @@ impl HelperDef for RenderToc {
                     true
                 } else {
                     // Levels that are larger than this would be folded.
-                    current_level - 1 < fold_level as usize
+                    level - 1 < fold_level as usize
                 }
             };
 

--- a/src/theme/book.js
+++ b/src/theme/book.js
@@ -451,6 +451,17 @@ function playpen_text(playpen) {
         try { localStorage.setItem('mdbook-sidebar', 'visible'); } catch (e) { }
     }
 
+
+    var sidebarAnchorToggles = document.querySelectorAll('#sidebar a.toggle');
+
+    function toggleSection(ev) {
+        ev.currentTarget.parentElement.classList.toggle('expanded');
+    }
+
+    Array.from(sidebarAnchorToggles).forEach(function (el) {
+        el.addEventListener('click', toggleSection);
+    });
+
     function hideSidebar() {
         html.classList.remove('sidebar-visible')
         html.classList.add('sidebar-hidden');

--- a/src/theme/css/chrome.css
+++ b/src/theme/css/chrome.css
@@ -376,7 +376,13 @@ ul#searchresults span.teaser em {
     padding-left: 0;
     line-height: 2.2em;
 }
+
+.chapter ol {
+    width: 100%;
+}
+
 .chapter li {
+    display: flex;
     color: var(--sidebar-non-existant);
 }
 .chapter li a {
@@ -390,8 +396,30 @@ ul#searchresults span.teaser em {
     color: var(--sidebar-active);
 }
 
-.chapter li .active {
+.chapter li a.active {
     color: var(--sidebar-active);
+}
+
+.chapter li > a.toggle {
+    cursor: pointer;
+    display: block;
+    margin-left: auto;
+    padding: 0 10px;
+    user-select: none;
+    opacity: 0.68;
+}
+
+.chapter li > a.toggle div {
+    transition: transform 0.5s;
+}
+
+/* collapse the section */
+.chapter li:not(.expanded) + li > ol {
+    display: none;
+}
+
+.chapter li.expanded > a.toggle div {
+    transform: rotate(90deg);
 }
 
 .spacer {

--- a/tests/rendered_output.rs
+++ b/tests/rendered_output.rs
@@ -235,7 +235,12 @@ fn check_second_toc_level() {
     let mut should_be = Vec::from(TOC_SECOND_LEVEL);
     should_be.sort();
 
-    let pred = descendants!(Class("chapter"), Name("li"), Name("li"), Name("a"));
+    let pred = descendants!(
+        Class("chapter"),
+        Name("li"),
+        Name("li"),
+        Name("a").and(Class("toggle").not())
+    );
 
     let mut children_of_children: Vec<_> = doc
         .find(pred)
@@ -254,7 +259,11 @@ fn check_first_toc_level() {
     should_be.extend(TOC_SECOND_LEVEL);
     should_be.sort();
 
-    let pred = descendants!(Class("chapter"), Name("li"), Name("a"));
+    let pred = descendants!(
+        Class("chapter"),
+        Name("li"),
+        Name("a").and(Class("toggle").not())
+    );
 
     let mut children: Vec<_> = doc
         .find(pred)


### PR DESCRIPTION
## What

Implementation of foldable table of contents.

Related issues #25 #187 

## How

By comparing values of `chapter.section`, one can determine whether current path is a subpath. For example `1.2.3.` is a subpath of `1.2.`, so we can expand the whole ancestor section at once.

## Features

- [x] **Foldable Section of Sidebar:** When `output.html.fold.enable` is set to `true`. You can toggle section to expand/collapse in sidebar. See **Screenshots** for more.
- [x] **`output.html.fold` Subtable config:** This config behaves like vim's `foldenable` and `foldlevel`, an is aimed at configuring sidebar section-folding behavior. 
    - **fold.enable:** Enable section-folding. When off, all folds are open.
  Defaults to `false`.
    - **fold.evel:** The higher the more folded regions are open. When level is 0, all
  folds are closed. Defaults to `0`.
- [x] Documentation update

## Breaking Changes

**No.** `output.html.fold.enable` defaults to `false`, so no any changes before enabling it.

## Screenshots


### mdBook User Guide

<img src="https://user-images.githubusercontent.com/14314532/64921739-7027dd00-d7f9-11e9-8ab5-7c835ffe95f1.gif" width="280px">

### TRPL

<img src="https://user-images.githubusercontent.com/14314532/64922428-af5a2c00-d801-11e9-9811-0364c7c98b2e.png" width="200px">

<details>
    <summary>Open to see more behaviors</summary>

#### enable = false 
<img src="https://user-images.githubusercontent.com/14314532/65048251-625b8e80-d996-11e9-8c93-61b7c704a7b9.png" width="200px">

#### enable = true, level = 0
<img src="https://user-images.githubusercontent.com/14314532/65048438-ab134780-d996-11e9-905e-b32368866d30.png" width="200px">

#### enable = true, level = 1
<img src="https://user-images.githubusercontent.com/14314532/65049502-6c7e8c80-d998-11e9-8467-1e555a7252b1.png" width="200px">

#### enable = true, level = 2

<img src="https://user-images.githubusercontent.com/14314532/65049573-87e99780-d998-11e9-8d6d-bfe9c4bc9438.png" width="200px">

</details>