### PR TITLE
Log deserialization errors for [html.config]

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -62,6 +62,7 @@ use toml_query::insert::TomlValueInsertExt;
 use toml_query::read::TomlValueReadExt;
 
 use crate::errors::*;
+use crate::utils;
 
 /// The overall configuration object for MDBook, essentially an in-memory
 /// representation of `book.toml`.
@@ -168,7 +169,13 @@ impl Config {
     /// HTML renderer is refactored to be less coupled to `mdbook` internals.
     #[doc(hidden)]
     pub fn html_config(&self) -> Option<HtmlConfig> {
-        self.get_deserialized("output.html").ok()
+        match self.get_deserialized("output.html") {
+            Ok(config) => Some(config),
+            Err(e) => {
+                utils::log_backtrace(&e.chain_err(|| "Parsing configuration [output.html]"));
+                None
+            }
+        }
     }
 
     /// Convenience function to fetch a value from the config and deserialize it

--- a/src/renderer/html_handlebars/hbs_renderer.rs
+++ b/src/renderer/html_handlebars/hbs_renderer.rs
@@ -381,7 +381,6 @@ fn make_data(
     html_config: &HtmlConfig,
 ) -> Result<serde_json::Map<String, serde_json::Value>> {
     trace!("make_data");
-    let html = config.html_config().unwrap_or_default();
 
     let mut data = serde_json::Map::new();
     data.insert(
@@ -408,18 +407,18 @@ fn make_data(
     data.insert("default_theme".to_owned(), json!(default_theme));
 
     // Add google analytics tag
-    if let Some(ref ga) = config.html_config().and_then(|html| html.google_analytics) {
+    if let Some(ref ga) = html_config.google_analytics {
         data.insert("google_analytics".to_owned(), json!(ga));
     }
 
-    if html.mathjax_support {
+    if html_config.mathjax_support {
         data.insert("mathjax_support".to_owned(), json!(true));
     }
 
     // Add check to see if there is an additional style
-    if !html.additional_css.is_empty() {
+    if !html_config.additional_css.is_empty() {
         let mut css = Vec::new();
-        for style in &html.additional_css {
+        for style in &html_config.additional_css {
             match style.strip_prefix(root) {
                 Ok(p) => css.push(p.to_str().expect("Could not convert to str")),
                 Err(_) => css.push(style.to_str().expect("Could not convert to str")),
@@ -429,9 +428,9 @@ fn make_data(
     }
 
     // Add check to see if there is an additional script
-    if !html.additional_js.is_empty() {
+    if !html_config.additional_js.is_empty() {
         let mut js = Vec::new();
-        for script in &html.additional_js {
+        for script in &html_config.additional_js {
             match script.strip_prefix(root) {
                 Ok(p) => js.push(p.to_str().expect("Could not convert to str")),
                 Err(_) => js.push(script.to_str().expect("Could not convert to str")),
@@ -440,7 +439,7 @@ fn make_data(
         data.insert("additional_js".to_owned(), json!(js));
     }
 
-    if html.playpen.editable && html.playpen.copy_js {
+    if html_config.playpen.editable && html_config.playpen.copy_js {
         data.insert("playpen_js".to_owned(), json!(true));
     }
 


### PR DESCRIPTION
Fixes #1032 

Log deserialization errors in `Config::html_config()`, instead of ignoring them.
After implementing this, the log appeared three times, caused by multiple calls to `html_config()`. Therefore, I de-duplicated that code.

## Example
Using this `book.toml`:
```toml
[output.html]
default-theme = "navy"
curly-quotes = "true"
# should have been: curly-quotes = true
```
The build log displays the error:
```
[~/src/mdBook]% cargo run -- build ./book-example
    Finished dev [unoptimized + debuginfo] target(s) in 0.07s
     Running `target/debug/mdbook build ./book-example`
2019-09-22 21:19:14 [INFO] (mdbook::book): Book building has started
2019-09-22 21:19:14 [INFO] (mdbook::book): Running the html backend
2019-09-22 21:19:14 [ERROR] (mdbook::utils): Error: Parsing configuration [output.html]
2019-09-22 21:19:14 [ERROR] (mdbook::utils):    Caused By: Couldn't deserialize the value
2019-09-22 21:19:14 [ERROR] (mdbook::utils):    Caused By: invalid type: string "true", expected a boolean for key `curly-quotes`
```
