### PR TITLE
Fix Search::use_boolean_and documents

### DIFF
--- a/book-example/src/format/config.md
+++ b/book-example/src/format/config.md
@@ -190,7 +190,7 @@ Available configuration options for the `[output.html.search]` table:
 - **teaser-word-count:** The number of words used for a search result teaser.
   Defaults to `30`.
 - **use-boolean-and:** Define the logical link between multiple search words. If
-  true, all search words must appear in each result. Defaults to `true`.
+  true, all search words must appear in each result. Defaults to `false`.
 - **boost-title:** Boost factor for the search result score if a search word
   appears in the header. Defaults to `2`.
 - **boost-hierarchy:** Boost factor for the search result score if a search word

--- a/src/config.rs
+++ b/src/config.rs
@@ -504,7 +504,7 @@ pub struct Search {
     /// The number of words used for a search result teaser. Default: `30`.
     pub teaser_word_count: u32,
     /// Define the logical link between multiple search words.
-    /// If true, all search words must appear in each result. Default: `true`.
+    /// If true, all search words must appear in each result. Default: `false`.
     pub use_boolean_and: bool,
     /// Boost factor for the search result score if a search word appears in the header.
     /// Default: `2`.


### PR DESCRIPTION
The comment and document say that `Search::user_boolean_and` defaults to `true`, but in fact, it is `false` by default.

https://github.com/rust-lang-nursery/mdBook/blob/a6f317e352855fe058af82d18cae5541c6b356d3/src/config.rs#L536

It seems that changing default behavior is not good, so I changed the related comment and the related doc.