### PR TITLE
Hide chromes default active button outline

### DIFF
--- a/src/theme/css/chrome.css
+++ b/src/theme/css/chrome.css
@@ -49,6 +49,9 @@ a > .hljs {
     cursor: pointer;
     transition: color 0.5s;
 }
+.menu-bar button:focus {
+    outline: 0;
+}
 @media only screen and (max-width: 420px) {
     #menu-bar i, #menu-bar .icon-button {
         padding: 0 5px;


### PR DESCRIPTION
This change resolves #990 by removing the blue outline around the menu bar buttons. The following gif demonstrates the resulting behavior.

![mdbook-990-fix](https://user-images.githubusercontent.com/3588764/66110785-5538c500-e57c-11e9-8191-df48428b673d.gif)
