### PR TITLE
I fixed a small gitignore bug

### DIFF
--- a/src/cmd/watch.rs
+++ b/src/cmd/watch.rs
@@ -53,7 +53,7 @@ fn remove_ignored_files(book_root: &PathBuf, paths: &[PathBuf]) -> Vec<PathBuf> 
         return vec![];
     }
 
-    let gitignore_path = book_root.with_file_name(".gitignore");
+    let gitignore_path = book_root.join(".gitignore");
 
     match gitignore::File::new(gitignore_path.as_path()) {
         Ok(exclusion_checker) => paths


### PR DESCRIPTION
The way it would join the paths could in some cases throw away the last part of the folder hierarchy before attaching the filename. Using `.join()` instead of `.with_file_name()` solves the issue.