### PR TITLE
Fix inline code display css

### DIFF
--- a/src/theme/css/chrome.css
+++ b/src/theme/css/chrome.css
@@ -182,8 +182,7 @@ html:not(.sidebar-visible) #menu-bar:not(:hover).folded > #menu-bar-sticky-conta
 /* Inline code */
 
 :not(pre) > .hljs {
-    display: inline-block;
-    vertical-align: middle;
+    display: inline;
     padding: 0.1em 0.3em;
     border-radius: 3px;
 }


### PR DESCRIPTION
I tested this by regenerating the `book-example` docs and they picked up the new CSS and the wrapping and triple-click selection worked as expected. Fixes: #821 