### PR TITLE
Add Ctrl-Enter shortcut command to playpen

### DIFF
--- a/src/theme/book.js
+++ b/src/theme/book.js
@@ -55,6 +55,15 @@ function playpen_text(playpen) {
                 editor.addEventListener("change", function (e) {
                     update_play_button(playpen_block, playground_crates);
                 });
+                // add Ctrl-Enter command to execute rust code
+                editor.commands.addCommand({
+                    name: "run",
+                    bindKey: {
+                        win: "Ctrl-Enter",
+                        mac: "Ctrl-Enter"
+                    },
+                    exec: _editor => run_rust_code(playpen_block)
+                });
             }
         }
     }


### PR DESCRIPTION
Keyboard shortcut to run code in playpen will increase usability.
This change make playpen able to execute rust code in it by pressing `Ctrl-Enter`.