### PR TITLE
Fix: Sticky header disappears by momentum scroll

### DIFF
--- a/src/theme/book.js
+++ b/src/theme/book.js
@@ -591,6 +591,6 @@ function playpen_text(playpen) {
             menu.classList.remove('bordered');
         }
 
-        previousScrollTop = document.scrollingElement.scrollTop;
+        previousScrollTop = Math.max(document.scrollingElement.scrollTop, 0);
     }, { passive: true });
 })();


### PR DESCRIPTION
In the default theme, there is sticky header.

![sticky_header](https://user-images.githubusercontent.com/31783570/67070744-d4a0d800-f1bb-11e9-913b-ab253434eb7f.png)

The header will be hidden when the page is scrolled down. like:

![スクリーンショット 2019-10-18 15 28 58](https://user-images.githubusercontent.com/31783570/67070827-06b23a00-f1bc-11e9-9285-eb57eb290321.png)

This behavior make a problem with momentum scroll.
With momentum scroll, `document.scrollingElement.scrollTop` can be negative number, so scrolling up above the upper limit of a page makes such logs below:

```
[Log] document.scrollingElement.scrollTop:0 (book.js, line 593)
[Log] document.scrollingElement.scrollTop:-1 (book.js, line 593)
[Log] document.scrollingElement.scrollTop:-2 (book.js, line 593)
[Log] document.scrollingElement.scrollTop:-4 (book.js, line 593)
[Log] document.scrollingElement.scrollTop:-10 (book.js, line 593)
[Log] document.scrollingElement.scrollTop:-12 (book.js, line 593)
[Log] document.scrollingElement.scrollTop:-11 (book.js, line 593)
[Log] document.scrollingElement.scrollTop:-10 (book.js, line 593)
[Log] document.scrollingElement.scrollTop:-7 (book.js, line 593)
[Log] document.scrollingElement.scrollTop:-4 (book.js, line 593)
[Log] document.scrollingElement.scrollTop:-2 (book.js, line 593)
[Log] document.scrollingElement.scrollTop:-1 (book.js, line 593)
[Log] document.scrollingElement.scrollTop:0 (book.js, line 593)
```

The last part of logs is detected as "scrolling down", so

![Oct-18-2019 15-38-59](https://user-images.githubusercontent.com/31783570/67071423-7248d700-f1bd-11e9-8b3e-9d808e6a8cbd.gif)

the header disappear.
I Fixed it by coercing the negative value of `document.scrollingElement.scrollTop` into 0.

this problem can be reproduce with macOS safari and iOS safari and maybe other momentum scrollable browsers.
