### PR TITLE
Fix "next chapter" spacer handling.

### DIFF
--- a/src/renderer/html_handlebars/helpers/navigation.rs
+++ b/src/renderer/html_handlebars/helpers/navigation.rs
@@ -69,7 +69,15 @@ fn find_chapter(
         // "index.md" (unless there really is an index.md in SUMMARY.md).
         match target {
             Target::Previous => return Ok(None),
-            Target::Next => match chapters.iter().skip(1).next() {
+            Target::Next => match chapters
+                .iter()
+                .filter(|chapter| {
+                    // Skip things like "spacer"
+                    chapter.contains_key("path")
+                })
+                .skip(1)
+                .next()
+            {
                 Some(chapter) => return Ok(Some(chapter.clone())),
                 None => return Ok(None),
             },

--- a/tests/dummy_book/src/SUMMARY.md
+++ b/tests/dummy_book/src/SUMMARY.md
@@ -1,6 +1,9 @@
 # Summary
 
 [Dummy Book](README.md)
+
+---
+
 [Introduction](intro.md)
 
 - [First Chapter](first/index.md)

--- a/tests/rendered_output.rs
+++ b/tests/rendered_output.rs
@@ -306,7 +306,7 @@ fn check_first_toc_level() {
 #[test]
 fn check_spacers() {
     let doc = root_index_html().unwrap();
-    let should_be = 1;
+    let should_be = 2;
 
     let num_spacers = doc
         .find(Class("chapter").descendant(Name("li").and(Class("spacer"))))


### PR DESCRIPTION
Fix "next chapter" detection in index.html when the next chapter is a spacer.

If the item in SUMMARY.md immediately after the first chapter is a spacer (`---`), then it was failing because that is not a real chapter.

Closes #1074