### PR TITLE
Add CSS `scroll-margin-top` to headings which contain link targets.

### DIFF
--- a/src/theme/css/chrome.css
+++ b/src/theme/css/chrome.css
@@ -45,7 +45,7 @@ a > .hljs {
     position: relative;
     padding: 0 8px;
     z-index: 10;
-    line-height: 50px;
+    line-height: var(--menu-bar-height);
     cursor: pointer;
     transition: color 0.5s;
 }
@@ -73,7 +73,7 @@ a > .hljs {
 }
 
 html:not(.sidebar-visible) #menu-bar:not(:hover).folded > #menu-bar-sticky-container {
-    transform: translateY(-60px);
+    transform: translateY(calc(-10px - var(--menu-bar-height)));
 }
 
 .left-buttons {
@@ -88,7 +88,7 @@ html:not(.sidebar-visible) #menu-bar:not(:hover).folded > #menu-bar-sticky-conta
     display: inline-block;
     font-weight: 200;
     font-size: 20px;
-    line-height: 50px;
+    line-height: var(--menu-bar-height);
     text-align: center;
     margin: 0;
     flex: 1;
@@ -446,7 +446,7 @@ ul#searchresults span.teaser em {
 .theme-popup {
     position: absolute;
     left: 10px;
-    top: 50px;
+    top: var(--menu-bar-height);
     z-index: 1000;
     border-radius: 4px;
     font-size: 0.7em;

--- a/src/theme/css/general.css
+++ b/src/theme/css/general.css
@@ -45,6 +45,13 @@ h4 a.header:target::before {
     width: 30px;
 }
 
+h1 a.header:target,
+h2 a.header:target,
+h3 a.header:target,
+h4 a.header:target {
+    scroll-margin-top: 62px;
+}
+
 .page {
     outline: 0;
     padding: 0 var(--page-padding);

--- a/src/theme/css/general.css
+++ b/src/theme/css/general.css
@@ -49,7 +49,7 @@ h1 a.header:target,
 h2 a.header:target,
 h3 a.header:target,
 h4 a.header:target {
-    scroll-margin-top: 62px;
+    scroll-margin-top: calc(var(--menu-bar-height) + 0.5em);
 }
 
 .page {

--- a/src/theme/css/variables.css
+++ b/src/theme/css/variables.css
@@ -5,6 +5,7 @@
     --sidebar-width: 300px;
     --page-padding: 15px;
     --content-max-width: 750px;
+    --menu-bar-height: 50px;
 }
 
 /* Themes */


### PR DESCRIPTION
This addresses #1040 "Menu bar covers section header on anchor links".

I haven't attempted to make the new margin not apply in cases where the top menu bar won't be visible.

I've tested it on desktop Firefox and Chromium.

The second commit adds a CSS variable for the menu-bar height, to make it less likely that the scroll-margin-top value will become outdated if someone changes the design.

